### PR TITLE
SUL23-135 | @jdwjdwjdw | Remove drop cap, splash text, and callout text from wysiwyg

### DIFF
--- a/docroot/profiles/custom/sul_profile/config/sync/editor.editor.stanford_html.yml
+++ b/docroot/profiles/custom/sul_profile/config/sync/editor.editor.stanford_html.yml
@@ -64,20 +64,11 @@ settings:
           label: 'Intro Text'
           element: '<p class="su-intro-text">'
         -
-          label: 'Splash Font'
-          element: '<p class="su-font-splash">'
-        -
           label: 'Quote Text'
           element: '<p class="su-quote-text">'
         -
-          label: 'Drop Cap First Letter'
-          element: '<p class="su-drop-cap">'
-        -
           label: 'Card Text'
           element: '<p class="su-related-text">'
-        -
-          label: 'Callout Text'
-          element: '<p class="su-callout-text">'
         -
           label: 'Sub Title'
           element: '<p class="su-subheading">'
@@ -123,6 +114,8 @@ settings:
         - justify
     media_media:
       allow_view_mode_override: true
+    linkit_extension:
+      linkit_enabled: false
 image_upload:
   status: false
   scheme: public


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- [SUL23-135](https://stanfordits.atlassian.net/browse/SUL23-135): FE-DEV | style Typography for SUL theme
- Remove Drop Cap, Splash Text, and Callout Text from the “Style” options

# Review By (Date)
- When convenient

# Steps to Test
1. Checkout branch and login to site
2. Add a basic page text area, confirm that you can't add the Drop Cap, Splash Text, and Callout Text styles.
3. Review code 🐦 

[SUL23-135]: https://stanfordits.atlassian.net/browse/SUL23-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ