### PR TITLE
Added Migration authentication for filemaker api for Press

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,8 @@
 {
-    "name": "su-sws/sul-gryphon",
+    "name": "su-sws/ace-stanfordlagunita",
     "type": "project",
     "license": "GPL-2.0-or-later",
-    "homepage": "https://www.drupal.org/project/drupal",
-    "support": {
-        "docs": "https://www.drupal.org/docs/user_guide/en/index.html",
-        "chat": "https://www.drupal.org/node/314178"
-    },
+    "homepage": "https://github.com/su-sws/ace-stanfordlagunita",
     "repositories": [
         {
             "type": "composer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b1394a27d25082d4f644d6a42f1ef86",
+    "content-hash": "8793adba194a9fa499b3671ed7f28a1b",
     "packages": [
         {
             "name": "acquia/blt",
@@ -3359,20 +3359,20 @@
         },
         {
             "name": "drupal/config_split",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/config_split.git",
-                "reference": "2.0.0"
+                "reference": "2.0.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/config_split-2.0.0.zip",
-                "reference": "2.0.0",
-                "shasum": "be9fd0aba1206e0f19e8448f69d4210e53dae069"
+                "url": "https://ftp.drupal.org/files/projects/config_split-2.0.1.zip",
+                "reference": "2.0.1",
+                "shasum": "e033a277995753c564f3a4681b88cd112e19ba2a"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9 || ^10"
+                "drupal/core": "^8.8 || ^9 || ^10 || ^11"
             },
             "conflict": {
                 "drush/drush": "<10"
@@ -3387,8 +3387,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0",
-                    "datestamp": "1707999066",
+                    "version": "2.0.1",
+                    "datestamp": "1711022056",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6352,17 +6352,17 @@
         },
         {
             "name": "drupal/graphql",
-            "version": "4.6.0",
+            "version": "4.7.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/graphql.git",
-                "reference": "8.x-4.6"
+                "reference": "8.x-4.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/graphql-8.x-4.6.zip",
-                "reference": "8.x-4.6",
-                "shasum": "629eb1d405ea35460e6f94bd46a20316adf4fbe9"
+                "url": "https://ftp.drupal.org/files/projects/graphql-8.x-4.7.zip",
+                "reference": "8.x-4.7",
+                "shasum": "aec6286cf550e5625d39e451284d33dd80568419"
             },
             "require": {
                 "drupal/core": "^9.3 || ^10",
@@ -6376,8 +6376,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-4.6",
-                    "datestamp": "1699463388",
+                    "version": "8.x-4.7",
+                    "datestamp": "1711037105",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -10714,20 +10714,20 @@
         },
         {
             "name": "drupal/shs",
-            "version": "2.0.0-rc4",
+            "version": "2.0.0-rc11",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/shs.git",
-                "reference": "2.0.0-rc4"
+                "reference": "2.0.0-rc11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/shs-2.0.0-rc4.zip",
-                "reference": "2.0.0-rc4",
-                "shasum": "15d4d84f4c91dc9d4a304bfec8255a13b75b2195"
+                "url": "https://ftp.drupal.org/files/projects/shs-2.0.0-rc11.zip",
+                "reference": "2.0.0-rc11",
+                "shasum": "b9a685ad99ab08446e765a9b08b2bec9f0cc6353"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9 || ^10"
+                "drupal/core": "^9 || ^10"
             },
             "require-dev": {
                 "drupal/chosen": "*"
@@ -10735,8 +10735,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0-rc4",
-                    "datestamp": "1681242239",
+                    "version": "2.0.0-rc11",
+                    "datestamp": "1711424677",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."
@@ -10751,6 +10751,10 @@
                 {
                     "name": "jhedstrom",
                     "homepage": "https://www.drupal.org/user/208732"
+                },
+                {
+                    "name": "joseph.olstad",
+                    "homepage": "https://www.drupal.org/user/1321830"
                 },
                 {
                     "name": "stBorchert",
@@ -14074,16 +14078,16 @@
         },
         {
             "name": "league/uri",
-            "version": "7.4.0",
+            "version": "7.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "bf414ba956d902f5d98bf9385fcf63954f09dce5"
+                "reference": "bedb6e55eff0c933668addaa7efa1e1f2c417cc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/bf414ba956d902f5d98bf9385fcf63954f09dce5",
-                "reference": "bf414ba956d902f5d98bf9385fcf63954f09dce5",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/bedb6e55eff0c933668addaa7efa1e1f2c417cc4",
+                "reference": "bedb6e55eff0c933668addaa7efa1e1f2c417cc4",
                 "shasum": ""
             },
             "require": {
@@ -14152,7 +14156,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.4.0"
+                "source": "https://github.com/thephpleague/uri/tree/7.4.1"
             },
             "funding": [
                 {
@@ -14160,20 +14164,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-01T06:24:25+00:00"
+            "time": "2024-03-23T07:42:40+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.4.0",
+            "version": "7.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "bd8c487ec236930f7bbc42b8d374fa882fbba0f3"
+                "reference": "8d43ef5c841032c87e2de015972c06f3865ef718"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/bd8c487ec236930f7bbc42b8d374fa882fbba0f3",
-                "reference": "bd8c487ec236930f7bbc42b8d374fa882fbba0f3",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/8d43ef5c841032c87e2de015972c06f3865ef718",
+                "reference": "8d43ef5c841032c87e2de015972c06f3865ef718",
                 "shasum": ""
             },
             "require": {
@@ -14236,7 +14240,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.4.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.4.1"
             },
             "funding": [
                 {
@@ -14244,7 +14248,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-24T15:40:42+00:00"
+            "time": "2024-03-23T07:42:40+00:00"
         },
         {
             "name": "loophp/phposinfo",
@@ -17101,16 +17105,16 @@
         },
         {
             "name": "su-sws/stanford_profile",
-            "version": "11.3.3",
+            "version": "11.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SU-SWS/stanford_profile.git",
-                "reference": "3ceb929293e2669525fd9dd33d405ae43485e1dd"
+                "reference": "ec2db06e44434d753bf54f4e3f86ce508c7aeb7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SU-SWS/stanford_profile/zipball/3ceb929293e2669525fd9dd33d405ae43485e1dd",
-                "reference": "3ceb929293e2669525fd9dd33d405ae43485e1dd",
+                "url": "https://api.github.com/repos/SU-SWS/stanford_profile/zipball/ec2db06e44434d753bf54f4e3f86ce508c7aeb7d",
+                "reference": "ec2db06e44434d753bf54f4e3f86ce508c7aeb7d",
                 "shasum": ""
             },
             "require": {
@@ -17281,22 +17285,22 @@
             "description": "Installation Profile for the Stanford Webservice's Jumpstart Product.",
             "support": {
                 "issues": "https://github.com/SU-SWS/stanford_profile/issues",
-                "source": "https://github.com/SU-SWS/stanford_profile/tree/11.3.3"
+                "source": "https://github.com/SU-SWS/stanford_profile/tree/11.3.6"
             },
-            "time": "2024-03-18T17:07:10+00:00"
+            "time": "2024-03-23T01:36:25+00:00"
         },
         {
             "name": "su-sws/stanford_profile_helper",
-            "version": "9.6.4",
+            "version": "9.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SU-SWS/stanford_profile_helper.git",
-                "reference": "1603727f9b61dc3d27df7243687d97959fc1d68e"
+                "reference": "62d51b369f9224e12fc76f48466306adb7eb1b4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SU-SWS/stanford_profile_helper/zipball/1603727f9b61dc3d27df7243687d97959fc1d68e",
-                "reference": "1603727f9b61dc3d27df7243687d97959fc1d68e",
+                "url": "https://api.github.com/repos/SU-SWS/stanford_profile_helper/zipball/62d51b369f9224e12fc76f48466306adb7eb1b4b",
+                "reference": "62d51b369f9224e12fc76f48466306adb7eb1b4b",
                 "shasum": ""
             },
             "require": {
@@ -17383,9 +17387,9 @@
             ],
             "description": "Helper Module For Stanford Profile",
             "support": {
-                "source": "https://github.com/SU-SWS/stanford_profile_helper/tree/9.6.4"
+                "source": "https://github.com/SU-SWS/stanford_profile_helper/tree/9.6.5"
             },
-            "time": "2024-03-20T18:09:44+00:00"
+            "time": "2024-03-22T03:55:00+00:00"
         },
         {
             "name": "su-sws/stanford_samlauth",
@@ -20571,16 +20575,16 @@
         },
         {
             "name": "tecnickcom/tcpdf",
-            "version": "6.7.3",
+            "version": "6.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tecnickcom/TCPDF.git",
-                "reference": "8389cec2c34926bb87e87736265f077ad822adeb"
+                "reference": "d4adef47ca21c90e6483d59dcb9e5b1023696937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/8389cec2c34926bb87e87736265f077ad822adeb",
-                "reference": "8389cec2c34926bb87e87736265f077ad822adeb",
+                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/d4adef47ca21c90e6483d59dcb9e5b1023696937",
+                "reference": "d4adef47ca21c90e6483d59dcb9e5b1023696937",
                 "shasum": ""
             },
             "require": {
@@ -20631,7 +20635,7 @@
             ],
             "support": {
                 "issues": "https://github.com/tecnickcom/TCPDF/issues",
-                "source": "https://github.com/tecnickcom/TCPDF/tree/6.7.3"
+                "source": "https://github.com/tecnickcom/TCPDF/tree/6.7.4"
             },
             "funding": [
                 {
@@ -20639,7 +20643,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-03-20T16:19:35+00:00"
+            "time": "2024-03-25T23:56:24+00:00"
         },
         {
             "name": "twig/twig",
@@ -22390,16 +22394,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "ced299686f41dce890debac69273b47ffe98a40c"
+                "reference": "4f988f8fdf580d53bdb2d1278fe93d1ed5462255"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ced299686f41dce890debac69273b47ffe98a40c",
-                "reference": "ced299686f41dce890debac69273b47ffe98a40c",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/4f988f8fdf580d53bdb2d1278fe93d1ed5462255",
+                "reference": "4f988f8fdf580d53bdb2d1278fe93d1ed5462255",
                 "shasum": ""
             },
             "require": {
@@ -22410,7 +22414,7 @@
             "require-dev": {
                 "phpstan/phpstan": "^1.0",
                 "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^6.0"
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
             },
             "type": "library",
             "autoload": {
@@ -22434,9 +22438,9 @@
                 "performance"
             ],
             "support": {
-                "irc": "irc://irc.freenode.org/composer",
+                "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/3.0.3"
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.4"
             },
             "funding": [
                 {
@@ -22452,7 +22456,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-25T21:32:43+00:00"
+            "time": "2024-03-26T18:29:49+00:00"
         },
         {
             "name": "dekor/php-array-table",
@@ -22982,29 +22986,30 @@
         },
         {
             "name": "drupal/devel",
-            "version": "5.1.2",
+            "version": "5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/devel.git",
-                "reference": "5.1.2"
+                "reference": "5.2.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/devel-5.1.2.zip",
-                "reference": "5.1.2",
-                "shasum": "9b35e38bf2043bf87f88585b3d9100f38da8f07f"
+                "url": "https://ftp.drupal.org/files/projects/devel-5.2.1.zip",
+                "reference": "5.2.1",
+                "shasum": "793861751e01092fe8bc7c0cd47589ebea2bb8df"
             },
             "require": {
                 "doctrine/common": "^2.7 || ^3.4",
-                "drupal/core": "^9 || ^10",
-                "php": ">=7.4",
+                "drupal/core": ">=10.0 <12.0.0-stable",
+                "php": ">=8.1",
                 "symfony/var-dumper": "^4 || ^5 || ^6"
             },
             "conflict": {
+                "drush/drush": "<12.5.1",
                 "kint-php/kint": "<3"
             },
             "require-dev": {
-                "drush/drush": "^11"
+                "drush/drush": "^12.5.1"
             },
             "suggest": {
                 "kint-php/kint": "Kint provides an informative display of arrays/objects. Useful for debugging and developing."
@@ -23012,16 +23017,11 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "5.1.2",
-                    "datestamp": "1686161028",
+                    "version": "5.2.1",
+                    "datestamp": "1711328410",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
-                    }
-                },
-                "drush": {
-                    "services": {
-                        "drush.services.yml": "^9 || ^10 || ^11"
                     }
                 }
             },
@@ -23555,16 +23555,16 @@
         },
         {
             "name": "mglaman/phpstan-drupal",
-            "version": "1.2.7",
+            "version": "1.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mglaman/phpstan-drupal.git",
-                "reference": "32f79fcf48c74532014248687ae3850581a22416"
+                "reference": "206285277fad650560cb26b43397b952228e3006"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mglaman/phpstan-drupal/zipball/32f79fcf48c74532014248687ae3850581a22416",
-                "reference": "32f79fcf48c74532014248687ae3850581a22416",
+                "url": "https://api.github.com/repos/mglaman/phpstan-drupal/zipball/206285277fad650560cb26b43397b952228e3006",
+                "reference": "206285277fad650560cb26b43397b952228e3006",
                 "shasum": ""
             },
             "require": {
@@ -23578,7 +23578,7 @@
             "require-dev": {
                 "behat/mink": "^1.8",
                 "composer/installers": "^1.9",
-                "drupal/core-recommended": "^9.0",
+                "drupal/core-recommended": "^10",
                 "drush/drush": "^10.0 || ^11 || ^12",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan-strict-rules": "^1.0",
@@ -23639,7 +23639,7 @@
             "description": "Drupal extension and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/mglaman/phpstan-drupal/issues",
-                "source": "https://github.com/mglaman/phpstan-drupal/tree/1.2.7"
+                "source": "https://github.com/mglaman/phpstan-drupal/tree/1.2.9"
             },
             "funding": [
                 {
@@ -23655,7 +23655,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-14T04:38:08+00:00"
+            "time": "2024-03-22T18:50:10+00:00"
         },
         {
             "name": "micheh/phpcs-gitlab",
@@ -24923,16 +24923,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.26.0",
+            "version": "1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "231e3186624c03d7e7c890ec662b81e6b0405227"
+                "reference": "86e4d5a4b036f8f0be1464522f4c6b584c452757"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/231e3186624c03d7e7c890ec662b81e6b0405227",
-                "reference": "231e3186624c03d7e7c890ec662b81e6b0405227",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/86e4d5a4b036f8f0be1464522f4c6b584c452757",
+                "reference": "86e4d5a4b036f8f0be1464522f4c6b584c452757",
                 "shasum": ""
             },
             "require": {
@@ -24964,22 +24964,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.26.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.27.0"
             },
-            "time": "2024-02-23T16:05:55+00:00"
+            "time": "2024-03-21T13:14:53+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.63",
+            "version": "1.10.65",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "ad12836d9ca227301f5fb9960979574ed8628339"
+                "reference": "3c657d057a0b7ecae19cb12db446bbc99d8839c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ad12836d9ca227301f5fb9960979574ed8628339",
-                "reference": "ad12836d9ca227301f5fb9960979574ed8628339",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/3c657d057a0b7ecae19cb12db446bbc99d8839c6",
+                "reference": "3c657d057a0b7ecae19cb12db446bbc99d8839c6",
                 "shasum": ""
             },
             "require": {
@@ -25028,7 +25028,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-18T16:53:53+00:00"
+            "time": "2024-03-23T10:30:26+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -25451,16 +25451,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.17",
+            "version": "9.6.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd"
+                "reference": "32c2c2d6580b1d8ab3c10b1e9e4dc263cc69bb04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1a156980d78a6666721b7e8e8502fe210b587fcd",
-                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/32c2c2d6580b1d8ab3c10b1e9e4dc263cc69bb04",
+                "reference": "32c2c2d6580b1d8ab3c10b1e9e4dc263cc69bb04",
                 "shasum": ""
             },
             "require": {
@@ -25534,7 +25534,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.17"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.18"
             },
             "funding": [
                 {
@@ -25550,7 +25550,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-23T13:14:51+00:00"
+            "time": "2024-03-21T12:07:32+00:00"
         },
         {
             "name": "react/promise",

--- a/docroot/profiles/lagunita/supress/config/sync/core.extension.yml
+++ b/docroot/profiles/lagunita/supress/config/sync/core.extension.yml
@@ -208,6 +208,7 @@ module:
   stanford_publication: 0
   stanford_samlauth: 0
   subrequests: 0
+  supress_helper: 0
   syslog: 0
   system: 0
   taxonomy: 0

--- a/docroot/profiles/lagunita/supress/modules/supress_helper/src/Plugin/migrate_plus/authentication/FileMakerAuth.php
+++ b/docroot/profiles/lagunita/supress/modules/supress_helper/src/Plugin/migrate_plus/authentication/FileMakerAuth.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\supress_helper\Plugin\migrate_plus\authentication;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate_plus\AuthenticationPluginBase;
+use GuzzleHttp\ClientInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides FileMaker authentication for the HTTP resource.
+ *
+ * source:
+ *   authentication:
+ *     plugin: press_filemaker
+ *     token_url: '[filemaker url]'
+ *     client_id: '[api user]'
+ *     client_secret: '[api password'
+ *
+ * @Authentication(
+ *   id = "press_filemaker",
+ *   title = @Translation("Press Filemaker")
+ * )
+ */
+class FileMakerAuth extends AuthenticationPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): AuthenticationPluginBase {
+    return new static($configuration, $plugin_id, $plugin_definition, $container->get('http_client'));
+  }
+
+  /**
+   * File maker auth plugin constructor.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \GuzzleHttp\ClientInterface $client
+   *   Guzzle client servicde.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, protected ClientInterface $client) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAuthenticationOptions(): array {
+    $response = $this->client->request('POST', $this->configuration['token_url'], [
+      'verify' => FALSE,
+      'headers' => ['Content-Type' => 'application/json'],
+      'auth' => [
+        $this->configuration['client_id'],
+        $this->configuration['client_secret'],
+      ],
+    ]);
+    $token_response = json_decode((string) $response->getBody(), TRUE, 513, JSON_THROW_ON_ERROR);
+
+    return [
+      'verify' => FALSE,
+      'headers' => [
+        'Authorization' => 'Bearer ' . $token_response['response']['token'],
+      ],
+    ];
+  }
+
+}

--- a/docroot/profiles/lagunita/supress/modules/supress_helper/src/Plugin/migrate_plus/authentication/FileMakerAuth.php
+++ b/docroot/profiles/lagunita/supress/modules/supress_helper/src/Plugin/migrate_plus/authentication/FileMakerAuth.php
@@ -43,7 +43,7 @@ class FileMakerAuth extends AuthenticationPluginBase implements ContainerFactory
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
    * @param \GuzzleHttp\ClientInterface $client
-   *   Guzzle client servicde.
+   *   Guzzle client service.
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, protected ClientInterface $client) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
@@ -53,6 +53,14 @@ class FileMakerAuth extends AuthenticationPluginBase implements ContainerFactory
    * {@inheritdoc}
    */
   public function getAuthenticationOptions(): array {
+    if (
+      !isset($this->configuration['token_url']) ||
+      !isset($this->configuration['client_id']) ||
+      !isset($this->configuration['client_secret'])
+    ) {
+      throw new \Exception('Missing required configuration settings');
+    }
+
     $response = $this->client->request('POST', $this->configuration['token_url'], [
       'verify' => FALSE,
       'headers' => ['Content-Type' => 'application/json'],

--- a/docroot/profiles/lagunita/supress/modules/supress_helper/supress_helper.info.yml
+++ b/docroot/profiles/lagunita/supress/modules/supress_helper/supress_helper.info.yml
@@ -1,0 +1,5 @@
+name: 'supress_helper'
+type: module
+description: 'Helper module'
+package: Stanford
+core_version_requirement: ^10 || ^11

--- a/docroot/profiles/lagunita/supress/modules/supress_helper/tests/src/Unit/Plugin/migrate_plus/authentication/FileMakerAuthTest.php
+++ b/docroot/profiles/lagunita/supress/modules/supress_helper/tests/src/Unit/Plugin/migrate_plus/authentication/FileMakerAuthTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\supress_helper\Unit\Plugin\migrate_plus\authentication;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\supress_helper\Plugin\migrate_plus\authentication\FileMakerAuth;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Stream;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ *
+ */
+class FileMakerAuthTest extends UnitTestCase {
+
+  public function testEmptyConfigFailure() {
+    $client = $this->createMock(ClientInterface::class);
+    $request = $this->createMock(RequestInterface::class);
+    $response = $this->createMock(ResponseInterface::class);
+    $client->method('request')->willThrowException(new ClientException('failed', $request, $response));
+    $container = new ContainerBuilder();
+    $container->set('http_client', $client);
+    $auth_plugin = FileMakerAuth::create($container, [], '', []);
+
+    $this->expectException(\Exception::class);
+    $auth_plugin->getAuthenticationOptions();
+  }
+
+  public function testFailedRequestFailure() {
+    $client = $this->createMock(ClientInterface::class);
+    $request = $this->createMock(RequestInterface::class);
+    $response = $this->createMock(ResponseInterface::class);
+    $client->method('request')->willThrowException(new ClientException('failed', $request, $response));
+    $container = new ContainerBuilder();
+    $container->set('http_client', $client);
+    $auth_plugin = FileMakerAuth::create($container, ['token_url' => 'https://localhost', 'client_id' => 'foo', 'client_secret' => 'bar'], '', []);
+
+    $this->expectException(ClientException::class);
+    $auth_plugin->getAuthenticationOptions();
+  }
+
+  public function testBadJsonFailure() {
+    $resource = fopen('php://memory','r+');
+    fwrite($resource, 'foobar');
+    rewind($resource);
+    $body = new Stream($resource);
+
+    $response = $this->createMock(ResponseInterface::class);
+    $response->method('getBody')->willReturn($body);
+
+    $client = $this->createMock(ClientInterface::class);
+    $client->method('request')->willReturn($response);
+
+
+    $container = new ContainerBuilder();
+    $container->set('http_client', $client);
+    $auth_plugin = FileMakerAuth::create($container, ['token_url' => 'https://localhost', 'client_id' => 'foo', 'client_secret' => 'bar'], '', []);
+
+    $this->expectException(\Exception::class);
+    $auth_plugin->getAuthenticationOptions();
+  }
+
+  public function testSuccess() {
+    $resource = fopen('php://memory', 'r+');
+    fwrite($resource, json_encode(['response' => ['token' => 'foobarbaz']]));
+    rewind($resource);
+    $body = new Stream($resource);
+
+    $response = $this->createMock(ResponseInterface::class);
+    $response->method('getBody')->willReturn($body);
+
+    $client = $this->createMock(ClientInterface::class);
+    $client->method('request')->willReturn($response);
+
+    $container = new ContainerBuilder();
+    $container->set('http_client', $client);
+    $auth_plugin = FileMakerAuth::create($container, [
+      'token_url' => 'https://localhost',
+      'client_id' => 'foo',
+      'client_secret' => 'bar',
+    ], '', []);
+
+    $options = $auth_plugin->getAuthenticationOptions();
+    $this->assertEquals(['Authorization' => 'Bearer foobarbaz'], $options['headers']);
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added migration authentication for the FileMaker API

# Steps to Test
1. Add the snippet to your migration config:
```
source:
  authentication:
    plugin: press_filemaker
    token_url: '[filemaker url]'
    client_id: '[api user]'
    client_secret: '[api password]'
```
2. Set the config settings via settings.php:
```
$config['migrate_plus.migration.[migration_name]']['source']['authentication'] = [
  'token_url' => 'API URL',
  'client_id' => 'API Client ID',
  'client_secret' => 'API Client Secret',
];
```
3. import configs
4. clear caches
5. run your importer.

