### PR TITLE
SUL23-504: Relabeled view display to match the others

### DIFF
--- a/docroot/profiles/lagunita/sul_profile/config/sync/views.view.sul_people.yml
+++ b/docroot/profiles/lagunita/sul_profile/config/sync/views.view.sul_people.yml
@@ -584,7 +584,7 @@ display:
         - 'config:field.storage.node.su_person_type_group'
   table_list_all:
     id: table_list_all
-    display_title: 'table - All Results'
+    display_title: 'Library People Table'
     display_plugin: viewfield_block
     position: 1
     display_options:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- It's nice when the labels match up for the different tabular layout list views.

# Review By (Date)
- EOW

# Urgency
- Not very.

# Steps to Test

1. Checkout code
2. `drush @library.local cim`
3. Make a page with a list paragraph.  Choose the `Library People` view.
4. Ensure the Display is now labeled "Library People Table".
5. Save the page, and make sure the table still works as expected in the front end.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket: SUL23-504
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
