### PR TITLE
SUL23-866: Hide body field for news and basic pages

### DIFF
--- a/docroot/profiles/lagunita/sul_profile/modules/sul_helper/sul_helper.module
+++ b/docroot/profiles/lagunita/sul_profile/modules/sul_helper/sul_helper.module
@@ -143,6 +143,13 @@ function sul_helper_form_node_form_alter(&$form, FormStateInterface $form_state,
     $form["#process"][] = '_sul_helper_basic_page_node_form_process';
   }
   $form["#process"][] = '_sul_helper_node_form_process';
+
+  // Hide body field for stanford_page and stanford_news
+  if (in_array($node->bundle(), ['stanford_page', 'stanford_news'])) {
+    if (isset($form['body'])) {
+      $form['body']['#access'] = FALSE;
+    }
+  }
 }
 
 /**

--- a/docroot/profiles/lagunita/sul_profile/modules/sul_helper/sul_helper.module
+++ b/docroot/profiles/lagunita/sul_profile/modules/sul_helper/sul_helper.module
@@ -6,6 +6,9 @@
  */
 
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\migrate\Plugin\MigrateSourceInterface;
@@ -129,6 +132,22 @@ function sul_helper_migrate_prepare_row(Row $row, MigrateSourceInterface $source
 }
 
 /**
+ * Implements hook_entity_field_access().
+ */
+function sul_helper_entity_field_access($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, FieldItemListInterface $items = NULL) {
+  // Hide body field for stanford_page and stanford_news content types.
+  if ($operation == 'edit' && $field_definition->getName() == 'body') {
+    $entity = $items ? $items->getEntity() : NULL;
+    if ($entity && $entity->getEntityTypeId() == 'node') {
+      if (in_array($entity->bundle(), ['stanford_page', 'stanford_news'])) {
+        return AccessResult::forbidden();
+      }
+    }
+  }
+  return AccessResult::neutral();
+}
+
+/**
  * Implements hook_form_BASE_FORM_ID_alter().
  */
 function sul_helper_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
@@ -143,13 +162,6 @@ function sul_helper_form_node_form_alter(&$form, FormStateInterface $form_state,
     $form["#process"][] = '_sul_helper_basic_page_node_form_process';
   }
   $form["#process"][] = '_sul_helper_node_form_process';
-
-  // Hide body field for stanford_page and stanford_news
-  if (in_array($node->bundle(), ['stanford_page', 'stanford_news'])) {
-    if (isset($form['body'])) {
-      $form['body']['#access'] = FALSE;
-    }
-  }
 }
 
 /**

--- a/docroot/profiles/lagunita/sul_profile/tests/codeception/acceptance/Content/HiddenBodyFieldCest.php
+++ b/docroot/profiles/lagunita/sul_profile/tests/codeception/acceptance/Content/HiddenBodyFieldCest.php
@@ -1,0 +1,127 @@
+<?php
+
+use Codeception\Attribute as CodeceptionAttribute;
+use Faker\Factory;
+
+/**
+ * Test that body field is hidden from stanford_page and stanford_news content types.
+ *
+ * This test verifies that the body field, which exists in upstream stanford_profile,
+ * is properly hidden in the library site's content editing forms.
+ */
+#[CodeceptionAttribute\Group('library')]
+#[CodeceptionAttribute\Group('content')]
+#[CodeceptionAttribute\Group('form-display')]
+class HiddenBodyFieldCest {
+
+  /**
+   * Faker service.
+   *
+   * @var \Faker\Generator
+   */
+  protected $faker;
+
+  /**
+   * Test constructor.
+   */
+  public function __construct() {
+    $this->faker = Factory::create();
+  }
+
+  /**
+   * Test that body field is hidden on stanford_page content type.
+   */
+  public function testBodyFieldHiddenOnStanfordPage(AcceptanceTester $I) {
+    // Create a stanford_page node.
+    $node = $I->createEntity([
+      'type' => 'stanford_page',
+      'title' => $this->faker->words(3, TRUE),
+    ]);
+
+    // Log in as a contributor who can edit content.
+    $I->logInWithRole('contributor');
+
+    // Navigate to the node edit form.
+    $I->amOnPage($node->toUrl('edit-form')->toString());
+
+    // Verify we're on the edit page.
+    $I->canSeeResponseCodeIs(200);
+
+    // The body field should NOT be visible on the form.
+    // Check that the field wrapper doesn't exist or is hidden.
+    $I->dontSeeElement('input[name="body[0][value]"]');
+    $I->dontSeeElement('textarea[name="body[0][value]"]');
+    $I->dontSee('Body', '.form-item label');
+  }
+
+  /**
+   * Test that body field is hidden on stanford_news content type.
+   */
+  public function testBodyFieldHiddenOnStanfordNews(AcceptanceTester $I) {
+    // Create a stanford_news node.
+    $node = $I->createEntity([
+      'type' => 'stanford_news',
+      'title' => $this->faker->words(3, TRUE),
+    ]);
+
+    // Log in as a contributor who can edit content.
+    $I->logInWithRole('contributor');
+
+    // Navigate to the node edit form.
+    $I->amOnPage($node->toUrl('edit-form')->toString());
+
+    // Verify we're on the edit page.
+    $I->canSeeResponseCodeIs(200);
+
+    // The body field should NOT be visible on the form.
+    // Check that the field wrapper doesn't exist or is hidden.
+    $I->dontSeeElement('input[name="body[0][value]"]');
+    $I->dontSeeElement('textarea[name="body[0][value]"]');
+    $I->dontSee('Body', '.form-item label');
+  }
+
+  /**
+   * Test that body field is hidden when creating new stanford_page.
+   */
+  public function testBodyFieldHiddenOnNewStanfordPage(AcceptanceTester $I) {
+    // Log in as a contributor who can create content.
+    $I->logInWithRole('contributor');
+
+    // Navigate to the node creation form.
+    $I->amOnPage('/node/add/stanford_page');
+
+    // Verify we're on the creation page.
+    $I->canSeeResponseCodeIs(200);
+
+    // The body field should NOT be visible on the form.
+    $I->dontSeeElement('input[name="body[0][value]"]');
+    $I->dontSeeElement('textarea[name="body[0][value]"]');
+    $I->dontSee('Body', '.form-item label');
+
+    // Verify that other expected fields ARE visible.
+    $I->canSeeElement('input[name="title[0][value]"]');
+  }
+
+  /**
+   * Test that body field is hidden when creating new stanford_news.
+   */
+  public function testBodyFieldHiddenOnNewStanfordNews(AcceptanceTester $I) {
+    // Log in as a contributor who can create content.
+    $I->logInWithRole('contributor');
+
+    // Navigate to the node creation form.
+    $I->amOnPage('/node/add/stanford_news');
+
+    // Verify we're on the creation page.
+    $I->canSeeResponseCodeIs(200);
+
+    // The body field should NOT be visible on the form.
+    $I->dontSeeElement('input[name="body[0][value]"]');
+    $I->dontSeeElement('textarea[name="body[0][value]"]');
+    $I->dontSee('Body', '.form-item label');
+
+    // Verify that other expected fields ARE visible.
+    $I->canSeeElement('input[name="title[0][value]"]');
+  }
+
+}

--- a/docroot/profiles/lagunita/sul_profile/tests/codeception/acceptance/Content/HiddenBodyFieldCest.php
+++ b/docroot/profiles/lagunita/sul_profile/tests/codeception/acceptance/Content/HiddenBodyFieldCest.php
@@ -51,7 +51,7 @@ class HiddenBodyFieldCest {
     // Check that the field wrapper doesn't exist or is hidden.
     $I->dontSeeElement('input[name="body[0][value]"]');
     $I->dontSeeElement('textarea[name="body[0][value]"]');
-    $I->dontSee('Body', '.form-item label');
+
   }
 
   /**
@@ -77,7 +77,7 @@ class HiddenBodyFieldCest {
     // Check that the field wrapper doesn't exist or is hidden.
     $I->dontSeeElement('input[name="body[0][value]"]');
     $I->dontSeeElement('textarea[name="body[0][value]"]');
-    $I->dontSee('Body', '.form-item label');
+    
   }
 
   /**
@@ -96,7 +96,6 @@ class HiddenBodyFieldCest {
     // The body field should NOT be visible on the form.
     $I->dontSeeElement('input[name="body[0][value]"]');
     $I->dontSeeElement('textarea[name="body[0][value]"]');
-    $I->dontSee('Body', '.form-item label');
 
     // Verify that other expected fields ARE visible.
     $I->canSeeElement('input[name="title[0][value]"]');
@@ -118,7 +117,6 @@ class HiddenBodyFieldCest {
     // The body field should NOT be visible on the form.
     $I->dontSeeElement('input[name="body[0][value]"]');
     $I->dontSeeElement('textarea[name="body[0][value]"]');
-    $I->dontSee('Body', '.form-item label');
 
     // Verify that other expected fields ARE visible.
     $I->canSeeElement('input[name="title[0][value]"]');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- here, we hide the body field from the editing form for stanford_news and basic pages.

# Review By (Date)
- When does this need to be reviewed by?

# Urgency
- How critical is this PR?

# Steps to Test

1. Do this
1. Then this
2. Then this

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
