### PR TITLE
SUL23-878 | increase stat card stat field char limit and add white background option

### DIFF
--- a/docroot/profiles/lagunita/sul_profile/config/sync/split/library/config_split.patch.core.entity_form_display.paragraph.stanford_stat_card.default.yml
+++ b/docroot/profiles/lagunita/sul_profile/config/sync/split/library/config_split.patch.core.entity_form_display.paragraph.stanford_stat_card.default.yml
@@ -1,0 +1,18 @@
+adding:
+  content:
+    su_stat_bg_color:
+      settings:
+        default_colors: '#2e2d29,#53565a,#544948,#8c1515,#620059,#007c92,#175e54,#e98300,#e04f39,#f4f4f4,#ffffff'
+    su_stat_stat:
+      third_party_settings:
+        maxlength:
+          maxlength_js: 12
+removing:
+  content:
+    su_stat_bg_color:
+      settings:
+        default_colors: '#2e2d29,#53565a,#544948,#8c1515,#620059,#007c92,#175e54,#e98300,#e04f39,#f4f4f4'
+    su_stat_stat:
+      third_party_settings:
+        maxlength:
+          maxlength_js: 6

--- a/docroot/profiles/lagunita/sul_profile/tests/codeception/functional/Paragraphs/StatCardCest.php
+++ b/docroot/profiles/lagunita/sul_profile/tests/codeception/functional/Paragraphs/StatCardCest.php
@@ -1,0 +1,115 @@
+<?php
+
+use Codeception\Attribute as CodeceptionAttribute;
+use Faker\Factory;
+
+/**
+ * Stat card paragraph tests.
+ */
+#[CodeceptionAttribute\Group('paragraphs')]
+#[CodeceptionAttribute\Group('stat_card')]
+class StatCardCest {
+
+  /**
+   * Faker service.
+   *
+   * @var \Faker\Generator
+   */
+  protected $faker;
+
+  /**
+   * Test constructor.
+   */
+  public function __construct() {
+    $this->faker = Factory::create();
+  }
+
+  /**
+   * Test stat field character limit validation through UI.
+   */
+  public function testStatFieldCharacterLimitValidation(FunctionalTester $I) {
+    $I->logInWithRole('site_manager');
+    
+    // Create initial paragraph with stat card
+    $paragraph = $I->createEntity([
+      'type' => 'stanford_stat_card',
+      'su_stat_stat' => '12345', // Start with valid value
+      'su_stat_headline' => $this->faker->words(3, TRUE),
+      'su_stat_bg_color' => '#ffffff',
+    ], 'paragraph');
+
+    $node = $I->createEntity([
+      'type' => 'stanford_page',
+      'title' => $this->faker->words(4, TRUE),
+      'su_page_components' => [
+        'target_id' => $paragraph->id(),
+        'entity' => $paragraph,
+      ],
+    ]);
+
+    // Edit the stat card through LPB controls
+    $I->amOnPage($node->toUrl('edit-form')->toString());
+    $I->scrollTo('.js-lpb-component', 0, -100);
+    $I->moveMouseOver('.js-lpb-component', 10, 10);
+    $I->click('Edit', '.lpb-controls');
+    $I->waitForText('Stat');
+    
+    // Try to enter more than 12 characters
+    $long_stat = '1234567890123'; // 13 characters
+    $I->fillField('[name*="su_stat_stat"]', $long_stat);
+    
+    // Save the component
+    $I->click('Save', '.ui-dialog-buttonset');
+    $I->waitForElementNotVisible('.ui-dialog');
+    $I->waitForText('123,456,789,012');
+    $I->see('123,456,789,012'); // First 12 characters
+    $I->dontSee('1234567890123'); // Full 13 characters
+  }
+
+  /**
+   * Test background color options include white.
+   */
+  // public function testBackgroundColorWhiteOption(FunctionalTester $I) {
+  //   $I->logInWithRole('site_manager');
+    
+  //   // Create initial paragraph with stat card
+  //   $paragraph = $I->createEntity([
+  //     'type' => 'stanford_stat_card',
+  //     'su_stat_stat' => '42',
+  //     'su_stat_headline' => $this->faker->words(3, TRUE),
+  //     'su_stat_bg_color' => '#000000', // Start with non-white
+  //   ], 'paragraph');
+
+  //   $node = $I->createEntity([
+  //     'type' => 'stanford_page',
+  //     'title' => $this->faker->words(4, TRUE),
+  //     'su_page_components' => [
+  //       'target_id' => $paragraph->id(),
+  //       'entity' => $paragraph,
+  //     ],
+  //   ]);
+
+  //   // Edit the stat card through LPB controls
+  //   $I->amOnPage($node->toUrl('edit-form')->toString());
+  //   $I->scrollTo('.js-lpb-component', 0, -100);
+  //   $I->moveMouseOver('.js-lpb-component', 10, 10);
+  //   $I->click('Edit', '.lpb-controls');
+  //   $I->scrollTo('.claro-details__summary', 0, -100);
+  //   $I->click('summary[role="button"]');
+  //   $I->scrollTo('.field--type-color-field-type', 0, -100);
+  //   $I->waitForText('Background color');
+    
+  //   // Verify white option exists
+  //   $I->seeElement('button[value="#ffffff"]');
+    
+  //   // Select white background
+  //   $I->click('button[value="#ffffff"]');
+    
+  //   // Save the component
+  //   $I->click('Save', '.ui-dialog-buttonset');
+  //   $I->waitForElementNotVisible('.ui-dialog');
+    
+  //   // Verify white background is applied
+  //   $I->seeElement('.su-stat-card[style*="background-color: #ffffff"]');
+  // }
+}

--- a/docroot/profiles/lagunita/sul_profile/tests/codeception/functional/Paragraphs/StatCardCest.php
+++ b/docroot/profiles/lagunita/sul_profile/tests/codeception/functional/Paragraphs/StatCardCest.php
@@ -61,7 +61,7 @@ class StatCardCest {
     // Save the component
     $I->click('Save', '.ui-dialog-buttonset');
     $I->waitForElementNotVisible('.ui-dialog');
-    $I->waitForText('123,456,789,012');
+    $I->waitForText('123,456,789,012', 10);
     $I->see('123,456,789,012'); // First 12 characters
     $I->dontSee('1,234,567,890,123'); // Full 13 characters
   }

--- a/docroot/profiles/lagunita/sul_profile/tests/codeception/functional/Paragraphs/StatCardCest.php
+++ b/docroot/profiles/lagunita/sul_profile/tests/codeception/functional/Paragraphs/StatCardCest.php
@@ -63,53 +63,6 @@ class StatCardCest {
     $I->waitForElementNotVisible('.ui-dialog');
     $I->waitForText('123,456,789,012');
     $I->see('123,456,789,012'); // First 12 characters
-    $I->dontSee('1234567890123'); // Full 13 characters
+    $I->dontSee('1,234,567,890,123'); // Full 13 characters
   }
-
-  /**
-   * Test background color options include white.
-   */
-  // public function testBackgroundColorWhiteOption(FunctionalTester $I) {
-  //   $I->logInWithRole('site_manager');
-    
-  //   // Create initial paragraph with stat card
-  //   $paragraph = $I->createEntity([
-  //     'type' => 'stanford_stat_card',
-  //     'su_stat_stat' => '42',
-  //     'su_stat_headline' => $this->faker->words(3, TRUE),
-  //     'su_stat_bg_color' => '#000000', // Start with non-white
-  //   ], 'paragraph');
-
-  //   $node = $I->createEntity([
-  //     'type' => 'stanford_page',
-  //     'title' => $this->faker->words(4, TRUE),
-  //     'su_page_components' => [
-  //       'target_id' => $paragraph->id(),
-  //       'entity' => $paragraph,
-  //     ],
-  //   ]);
-
-  //   // Edit the stat card through LPB controls
-  //   $I->amOnPage($node->toUrl('edit-form')->toString());
-  //   $I->scrollTo('.js-lpb-component', 0, -100);
-  //   $I->moveMouseOver('.js-lpb-component', 10, 10);
-  //   $I->click('Edit', '.lpb-controls');
-  //   $I->scrollTo('.claro-details__summary', 0, -100);
-  //   $I->click('summary[role="button"]');
-  //   $I->scrollTo('.field--type-color-field-type', 0, -100);
-  //   $I->waitForText('Background color');
-    
-  //   // Verify white option exists
-  //   $I->seeElement('button[value="#ffffff"]');
-    
-  //   // Select white background
-  //   $I->click('button[value="#ffffff"]');
-    
-  //   // Save the component
-  //   $I->click('Save', '.ui-dialog-buttonset');
-  //   $I->waitForElementNotVisible('.ui-dialog');
-    
-  //   // Verify white background is applied
-  //   $I->seeElement('.su-stat-card[style*="background-color: #ffffff"]');
-  // }
 }

--- a/docroot/profiles/lagunita/sul_profile/tests/codeception/functional/Paragraphs/StatCardCest.php
+++ b/docroot/profiles/lagunita/sul_profile/tests/codeception/functional/Paragraphs/StatCardCest.php
@@ -56,7 +56,7 @@ class StatCardCest {
     
     // Try to enter more than 12 characters
     $long_stat = '1234567890123'; // 13 characters
-    $I->fillField('[name*="su_stat_stat"]', $long_stat);
+    $I->fillField('su_stat_stat[0][value]', $long_stat);
     
     // Save the component
     $I->click('Save', '.ui-dialog-buttonset');

--- a/docroot/profiles/lagunita/sul_profile/tests/codeception/functional/Paragraphs/StatCardCest.php
+++ b/docroot/profiles/lagunita/sul_profile/tests/codeception/functional/Paragraphs/StatCardCest.php
@@ -54,9 +54,10 @@ class StatCardCest {
     $I->click('Edit', '.lpb-controls');
     $I->waitForText('Stat');
     
+    $I->waitForElement('[data-drupal-selector=edit-su-stat-stat-0-value]', 10);
     // Try to enter more than 12 characters
     $long_stat = '1234567890123'; // 13 characters
-    $I->fillField('su_stat_stat[0][value]', $long_stat);
+    $I->fillField('[data-drupal-selector=edit-su-stat-stat-0-value]', $long_stat);
     
     // Save the component
     $I->click('Save', '.ui-dialog-buttonset');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SUL23-878 | increase stat card stat field char limit and add white background option

# Review By (Date)
- When possible

# Steps to Test

1. Confirm that you are able to add up to 12 characters in the stat field
2. Confirm that you are able to select the white background color
3. Review code

# Associated Issues and/or People
- SUL23-878
