### PR TITLE
ANES3-347: Initial Sliding Poster paragraph type build

### DIFF
--- a/docroot/profiles/lagunita/anes_profile/config/sync/graphql_compose.settings.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/graphql_compose.settings.yml
@@ -267,6 +267,9 @@ entity_config:
     stanford_wysiwyg:
       enabled: true
       query_load_enabled: true
+    anes_sliding_poster:
+      enabled: true
+      query_load_enabled: true
   redirect:
     redirect:
       enabled: true
@@ -991,6 +994,17 @@ field_config:
         enabled: true
     stanford_wysiwyg:
       su_wysiwyg_text:
+        enabled: true
+    anes_sliding_poster:
+      anes_sliding_headline:
+        enabled: true
+      anes_sliding_superhead:
+        enabled: true
+      anes_sliding_body:
+        enabled: true
+      anes_sliding_bgimage:
+        enabled: true
+      anes_sliding_link:
         enabled: true
   su_policy_log:
     su_policy_log:

--- a/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/config_split.patch.field.field.paragraph.stanford_card.su_card_link.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/config_split.patch.field.field.paragraph.stanford_card.su_card_link.yml
@@ -1,6 +1,0 @@
-adding:
-  settings:
-    title: 1
-removing:
-  settings:
-    title: 2

--- a/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/config_split.patch.field.field.paragraph.stanford_card.su_card_link.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/config_split.patch.field.field.paragraph.stanford_card.su_card_link.yml
@@ -1,0 +1,6 @@
+adding:
+  settings:
+    title: 1
+removing:
+  settings:
+    title: 2

--- a/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/core.entity_form_display.paragraph.anes_sliding_poster.default.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/core.entity_form_display.paragraph.anes_sliding_poster.default.yml
@@ -1,0 +1,68 @@
+uuid: e2264143-eb05-4c15-b9e2-066b22dd5015
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.anes_sliding_poster.anes_sliding_bgimage
+    - field.field.paragraph.anes_sliding_poster.anes_sliding_body
+    - field.field.paragraph.anes_sliding_poster.anes_sliding_headline
+    - field.field.paragraph.anes_sliding_poster.anes_sliding_link
+    - field.field.paragraph.anes_sliding_poster.anes_sliding_superhead
+    - paragraphs.paragraphs_type.anes_sliding_poster
+  module:
+    - link
+    - media_library
+    - text
+id: paragraph.anes_sliding_poster.default
+targetEntityType: paragraph
+bundle: anes_sliding_poster
+mode: default
+content:
+  anes_sliding_bgimage:
+    type: media_library_widget
+    weight: 0
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+  anes_sliding_body:
+    type: text_textarea
+    weight: 3
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  anes_sliding_headline:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  anes_sliding_link:
+    type: link_default
+    weight: 4
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  anes_sliding_superhead:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 5
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  created: true

--- a/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/core.entity_view_display.paragraph.anes_sliding_poster.default.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/core.entity_view_display.paragraph.anes_sliding_poster.default.yml
@@ -1,0 +1,65 @@
+uuid: e8e7fdc3-a152-4719-abf3-de47c3f560cc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.anes_sliding_poster.anes_sliding_bgimage
+    - field.field.paragraph.anes_sliding_poster.anes_sliding_body
+    - field.field.paragraph.anes_sliding_poster.anes_sliding_headline
+    - field.field.paragraph.anes_sliding_poster.anes_sliding_link
+    - field.field.paragraph.anes_sliding_poster.anes_sliding_superhead
+    - paragraphs.paragraphs_type.anes_sliding_poster
+  module:
+    - link
+    - text
+id: paragraph.anes_sliding_poster.default
+targetEntityType: paragraph
+bundle: anes_sliding_poster
+mode: default
+content:
+  anes_sliding_bgimage:
+    type: entity_reference_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  anes_sliding_body:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  anes_sliding_headline:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  anes_sliding_link:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  anes_sliding_superhead:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.field.paragraph.anes_sliding_poster.anes_sliding_bgimage.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.field.paragraph.anes_sliding_poster.anes_sliding_bgimage.yml
@@ -1,0 +1,29 @@
+uuid: 6093552a-0292-4663-8edc-bd614f9f4325
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.anes_sliding_bgimage
+    - media.type.image
+    - paragraphs.paragraphs_type.anes_sliding_poster
+id: paragraph.anes_sliding_poster.anes_sliding_bgimage
+field_name: anes_sliding_bgimage
+entity_type: paragraph
+bundle: anes_sliding_poster
+label: 'Background Image'
+description: 'The background image for the Sliding Poster.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.field.paragraph.anes_sliding_poster.anes_sliding_body.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.field.paragraph.anes_sliding_poster.anes_sliding_body.yml
@@ -1,0 +1,24 @@
+uuid: e2be9892-37df-4655-894c-6833179c1aad
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.anes_sliding_body
+    - filter.format.stanford_minimal_html
+    - paragraphs.paragraphs_type.anes_sliding_poster
+  module:
+    - text
+id: paragraph.anes_sliding_poster.anes_sliding_body
+field_name: anes_sliding_body
+entity_type: paragraph
+bundle: anes_sliding_poster
+label: Description
+description: 'The body text for the Sliding Poster.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - stanford_minimal_html
+field_type: text_long

--- a/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.field.paragraph.anes_sliding_poster.anes_sliding_headline.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.field.paragraph.anes_sliding_poster.anes_sliding_headline.yml
@@ -1,0 +1,19 @@
+uuid: 03296a6d-ce7f-4d83-a614-bdffa0e16da4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.anes_sliding_headline
+    - paragraphs.paragraphs_type.anes_sliding_poster
+id: paragraph.anes_sliding_poster.anes_sliding_headline
+field_name: anes_sliding_headline
+entity_type: paragraph
+bundle: anes_sliding_poster
+label: Headline
+description: 'The headline for the Sliding Poster.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.field.paragraph.anes_sliding_poster.anes_sliding_link.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.field.paragraph.anes_sliding_poster.anes_sliding_link.yml
@@ -1,0 +1,27 @@
+uuid: 787a8137-a412-476d-b8d8-6da4d28c3a49
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.anes_sliding_link
+    - paragraphs.paragraphs_type.anes_sliding_poster
+  module:
+    - link
+    - stanford_fields
+third_party_settings:
+  stanford_fields:
+    force_relative: true
+id: paragraph.anes_sliding_poster.anes_sliding_link
+field_name: anes_sliding_link
+entity_type: paragraph
+bundle: anes_sliding_poster
+label: 'CTA Link'
+description: 'The link URL and text for the Sliding Poster button.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: link

--- a/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.field.paragraph.anes_sliding_poster.anes_sliding_superhead.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.field.paragraph.anes_sliding_poster.anes_sliding_superhead.yml
@@ -1,0 +1,19 @@
+uuid: 80feb8c1-53fd-4a0e-8265-6cda6f9b81b4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.anes_sliding_superhead
+    - paragraphs.paragraphs_type.anes_sliding_poster
+id: paragraph.anes_sliding_poster.anes_sliding_superhead
+field_name: anes_sliding_superhead
+entity_type: paragraph
+bundle: anes_sliding_poster
+label: Superhead
+description: 'The superhead for the Sliding Poster.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.storage.paragraph.anes_sliding_bgimage.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.storage.paragraph.anes_sliding_bgimage.yml
@@ -1,0 +1,20 @@
+uuid: 3d168d64-b5a3-4d22-b5cc-c54a594c3faa
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - paragraphs
+id: paragraph.anes_sliding_bgimage
+field_name: anes_sliding_bgimage
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.storage.paragraph.anes_sliding_body.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.storage.paragraph.anes_sliding_body.yml
@@ -1,0 +1,19 @@
+uuid: 3766a233-55d8-4283-a8fc-df0c9b490e24
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.anes_sliding_body
+field_name: anes_sliding_body
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.storage.paragraph.anes_sliding_headline.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.storage.paragraph.anes_sliding_headline.yml
@@ -1,0 +1,21 @@
+uuid: c8f4436a-c518-4275-9091-6b403ec0e621
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.anes_sliding_headline
+field_name: anes_sliding_headline
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.storage.paragraph.anes_sliding_link.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.storage.paragraph.anes_sliding_link.yml
@@ -1,0 +1,19 @@
+uuid: 0dfd0864-b132-48ef-aa73-d3edde446b45
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.anes_sliding_link
+field_name: anes_sliding_link
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.storage.paragraph.anes_sliding_superhead.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/field.storage.paragraph.anes_sliding_superhead.yml
@@ -1,0 +1,21 @@
+uuid: 61a56c6c-fd42-43df-aa08-47266e0e41d8
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.anes_sliding_superhead
+field_name: anes_sliding_superhead
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/paragraphs.paragraphs_type.anes_sliding_poster.yml
+++ b/docroot/profiles/lagunita/anes_profile/config/sync/split/anes/paragraphs.paragraphs_type.anes_sliding_poster.yml
@@ -1,0 +1,10 @@
+uuid: 7f77f8f3-87d9-4c01-aa32-2d2f89a13f47
+langcode: en
+status: true
+dependencies: {  }
+id: anes_sliding_poster
+label: 'Sliding Poster'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
This PR implements the "Sliding Poster" paragraph type for the Anesthesiology profile, as described in [ANES3-347](https://stanfordits.atlassian.net/browse/ANES3-347). The new paragraph is similar to the Card paragraph, with fields for Superhead, Headline, WYSIWYG Description, CTA Link, and Background Image. All configuration, form display, view display, and GraphQL integration are included.

# Review By (Date)
No hard deadline, but review as soon as possible to unblock related work.

# Urgency
Medium.

# Steps to Test

1. Sync configuration (`drush @anes.local config-import -y`).
2. Add a "Sliding Poster" paragraph to a test node.
3. Review fields: Superhead, Headline, Description, CTA Link, and Background Image.
4. (Optional) Query the new paragraph type via GraphQL and confirm all fields are available.

# Additional Review
I called out items requiring additional review in separate comments.

# Associated Issues and/or People
- JIRA ticket: [ANES3-347](https://stanfordits.atlassian.net/browse/ANES3-347)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)


[ANES3-347]: https://stanfordits.atlassian.net/browse/ANES3-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANES3-347]: https://stanfordits.atlassian.net/browse/ANES3-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ