### PR TITLE
Comment out anes to skip it in tests and deployments

### DIFF
--- a/drush/drush.yml
+++ b/drush/drush.yml
@@ -24,7 +24,7 @@ command:
         - 'stanfordpress@svn-45197.prod.hosting.acquia.com:stanfordpress.git'
         - 'stanfordsummer@svn-45197.prod.hosting.acquia.com:stanfordsummer.git'
         # Anesthesiology is on stanfordgryphon.
-        - 'stanfordgryphon@svn-23450.prod.hosting.acquia.com:stanfordgryphon.git'
+        # - 'stanfordgryphon@svn-23450.prod.hosting.acquia.com:stanfordgryphon.git'
       post-build-script: drush/deploy-cleanup.sh
       artifact-dir: deploy
       alias-dir: drush/sites
@@ -35,7 +35,7 @@ command:
         - /mnt/gfs/stanfordlagunita.test/secrets.settings.php
         - /mnt/gfs/stanfordlagunita.test/nobackup/oauth/
       multisites:
-        - anes
+        # - anes
         - default
         - library
         - summer


### PR DESCRIPTION
This pull request makes minor configuration changes to the `drush/drush.yml` file, commenting out entries related to the `stanfordgryphon` repository and the `anes` multisite. These changes likely reflect a temporary exclusion or deprecation of these components from the deployment process.