### PR TITLE
CSP-115: Create poster card paragraph variant

### DIFF
--- a/docroot/profiles/lagunita/csp_profile/config/sync/config_split.config_split.csp.yml
+++ b/docroot/profiles/lagunita/csp_profile/config/sync/config_split.config_split.csp.yml
@@ -16,6 +16,7 @@ complete_list:
   - 'field.field.node.csp_*'
   - 'field.field.media.csp_*'
   - 'field.field.paragraph.csp_*'
+  - 'field.field.paragraph.stanford_card.csp_*'
   - 'field.field.config_pages.csp_*'
   - 'field.field.taxonomy_term.csp_*'
   - 'field.storage.node.csp_*'

--- a/docroot/profiles/lagunita/csp_profile/config/sync/graphql_compose.settings.yml
+++ b/docroot/profiles/lagunita/csp_profile/config/sync/graphql_compose.settings.yml
@@ -983,6 +983,8 @@ field_config:
         enabled: true
       su_card_super_header:
         enabled: true
+      csp_card_bg_color:
+        enabled: true
     stanford_entity:
       su_entity_button:
         enabled: true

--- a/docroot/profiles/lagunita/csp_profile/config/sync/split/csp/config_split.patch.core.entity_form_display.paragraph.stanford_card.default.yml
+++ b/docroot/profiles/lagunita/csp_profile/config/sync/split/csp/config_split.patch.core.entity_form_display.paragraph.stanford_card.default.yml
@@ -1,0 +1,15 @@
+adding:
+  dependencies:
+    config:
+      - field.field.paragraph.stanford_card.csp_card_bg_color
+    module:
+      - color_field
+  content:
+    csp_card_bg_color:
+      type: color_field_widget_box
+      weight: 7
+      region: content
+      settings:
+        default_colors: '#8c1515,#007c92,#620059,#175e54,#2e2d29,#f4f4f4'
+      third_party_settings: {  }
+removing: {  }

--- a/docroot/profiles/lagunita/csp_profile/config/sync/split/csp/field.field.paragraph.stanford_card.csp_card_bg_color.yml
+++ b/docroot/profiles/lagunita/csp_profile/config/sync/split/csp/field.field.paragraph.stanford_card.csp_card_bg_color.yml
@@ -1,0 +1,22 @@
+uuid: 5c49d169-e0f5-4420-8555-1f69e8087e09
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.csp_card_bg_color
+    - paragraphs.paragraphs_type.stanford_card
+  module:
+    - color_field
+id: paragraph.stanford_card.csp_card_bg_color
+field_name: csp_card_bg_color
+entity_type: paragraph
+bundle: stanford_card
+label: 'Poster background color'
+description: 'The background color used behind the card when displayed in the Poster variant.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  opacity: 0
+field_type: color_field_type

--- a/docroot/profiles/lagunita/csp_profile/config/sync/split/csp/field.storage.paragraph.csp_card_bg_color.yml
+++ b/docroot/profiles/lagunita/csp_profile/config/sync/split/csp/field.storage.paragraph.csp_card_bg_color.yml
@@ -1,0 +1,20 @@
+uuid: 9e81a7d3-c7c0-42a9-a749-908556b9c404
+langcode: en
+status: true
+dependencies:
+  module:
+    - color_field
+    - paragraphs
+id: paragraph.csp_card_bg_color
+field_name: csp_card_bg_color
+entity_type: paragraph
+type: color_field_type
+settings:
+  format: hexhex
+module: color_field
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/csp_helper.libraries.yml
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/csp_helper.libraries.yml
@@ -1,0 +1,5 @@
+card_poster_preview:
+  version: 1.x
+  css:
+    theme:
+      css/card-poster-preview.css: {}

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/csp_helper.libraries.yml
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/csp_helper.libraries.yml
@@ -3,3 +3,5 @@ card_poster_preview:
   css:
     theme:
       css/card-poster-preview.css: {}
+  dependencies:
+    - jumpstart_ui/components.card

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/css/card-poster-preview.css
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/css/card-poster-preview.css
@@ -1,26 +1,55 @@
 /* Editor-preview styling for the Poster card variant (CSP-115).
-   Public rendering is handled by the Next.js frontend (CSP-108). */
-.csp-card-variant-poster {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: stretch;
-  gap: 0.375rem;
+   This approximates the design inside the Layout Paragraphs builder
+   so editors can tell a Poster card apart from a default card.
+
+   CspCardBehaviors::view() switches the ui_patterns variant to "postcard",
+   so Decanter's .su-card--horizontal supplies the grid.
+   Only the poster's color treatment lives in this file.
+
+   The variant class sits on the paragraph wrapper, which is the
+   .js-lpb-component div rather than the card itself, so the card is always
+   addressed as a descendant.
+*/
+
+/* A little breathing room around the image and the color panel. Matching the
+   upstream selector's specificity, which sets padding: 3rem here. */
+.csp-card-variant-poster .su-card--horizontal:not(.su-card--link) {
+  padding: 1rem;
+  border: 0;
   box-shadow: none;
-  background: transparent;
 }
 
-.csp-card-variant-poster .paragraph-su-card-media,
-.csp-card-variant-poster [class*="card_image"] {
-  flex: 1 1 45%;
-  min-width: 12rem;
+/* The grid stretches the media wrapper to the row height already; these pass
+   that height down to the image so it matches the color panel. */
+.csp-card-variant-poster .su-card .media-entity-wrapper,
+.csp-card-variant-poster .su-card .media-entity-wrapper > *,
+.csp-card-variant-poster .su-card picture {
+  display: block;
+  height: 100%;
 }
 
-.csp-card-variant-poster .paragraph-su-card-body,
-.csp-card-variant-poster [class*="card_body"] {
-  flex: 1 1 45%;
-  min-width: 12rem;
-  padding: 1.5rem;
-  border-radius: 20px;
-  color: #fff;
+.csp-card-variant-poster .su-card img {
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
+  object-fit: cover;
+}
+
+/* Upstream zeroes the contents padding in horizontal mode; the poster needs it
+   back so the text sits inside the color panel. */
+.csp-card-variant-poster .su-card .su-card__contents {
+  padding: 1em;
+  border-radius: 12px;
+  color: var(--csp-poster-fg, #fff);
   background: var(--csp-poster-bg, #8c1515);
+}
+
+/* Upstream pulls the panel's first child up by -.3em, which lifts the
+   superhead out through the top of the color panel. */
+.csp-card-variant-poster .su-card .su-card__contents > :first-child {
+  margin-top: 0;
+}
+
+.csp-card-variant-poster .su-card .su-card__contents a {
+  color: var(--csp-poster-fg, #fff);
 }

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/css/card-poster-preview.css
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/css/card-poster-preview.css
@@ -1,55 +1,64 @@
 /* Editor-preview styling for the Poster card variant (CSP-115).
    This approximates the design inside the Layout Paragraphs builder
    so editors can tell a Poster card apart from a default card.
+   The Next.js frontend owns the real presentation.
 
-   CspCardBehaviors::view() switches the ui_patterns variant to "postcard",
-   so Decanter's .su-card--horizontal supplies the grid.
-   Only the poster's color treatment lives in this file.
-
-   The variant class sits on the paragraph wrapper, which is the
-   .js-lpb-component div rather than the card itself, so the card is always
-   addressed as a descendant.
+   CspHelperHooks::uiPatternsInfoAlter() registers a "poster" variant on the
+   card pattern and CspCardBehaviors::view() selects it, so the card carries
+   the CSP-owned "su-card--poster" modifier class.
 */
 
-/* A little breathing room around the image and the color panel. Matching the
-   upstream selector's specificity, which sets padding: 3rem here. */
-.csp-card-variant-poster .su-card--horizontal:not(.su-card--link) {
+/* Image beside the color panel. */
+.su-card.su-card--poster {
+  display: grid;
+  grid-template-columns: 100%;
+  gap: 2.31rem;
   padding: 1rem;
   border: 0;
   box-shadow: none;
 }
 
+@media only screen and (min-width: 576px) {
+  .su-card.su-card--poster {
+    grid-template-columns: 1fr 2fr;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .su-card.su-card--poster {
+    grid-template-columns: 1fr 1fr;
+    gap: 2.6rem;
+  }
+}
+
 /* The grid stretches the media wrapper to the row height already; these pass
    that height down to the image so it matches the color panel. */
-.csp-card-variant-poster .su-card .media-entity-wrapper,
-.csp-card-variant-poster .su-card .media-entity-wrapper > *,
-.csp-card-variant-poster .su-card picture {
+.su-card--poster .media-entity-wrapper,
+.su-card--poster .media-entity-wrapper > *,
+.su-card--poster picture {
   display: block;
   height: 100%;
 }
 
-.csp-card-variant-poster .su-card img {
+.su-card--poster img {
   width: 100%;
   height: 100%;
   border-radius: 12px;
   object-fit: cover;
 }
 
-/* Upstream zeroes the contents padding in horizontal mode; the poster needs it
-   back so the text sits inside the color panel. */
-.csp-card-variant-poster .su-card .su-card__contents {
+.su-card--poster .su-card__contents {
   padding: 1em;
   border-radius: 12px;
   color: var(--csp-poster-fg, #fff);
   background: var(--csp-poster-bg, #8c1515);
 }
 
-/* Upstream pulls the panel's first child up by -.3em, which lifts the
-   superhead out through the top of the color panel. */
-.csp-card-variant-poster .su-card .su-card__contents > :first-child {
+/* Keep the superhead from riding up out of the top of the color panel. */
+.su-card--poster .su-card__contents > :first-child {
   margin-top: 0;
 }
 
-.csp-card-variant-poster .su-card .su-card__contents a {
+.su-card--poster .su-card__contents a {
   color: var(--csp-poster-fg, #fff);
 }

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/css/card-poster-preview.css
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/css/card-poster-preview.css
@@ -1,0 +1,26 @@
+/* Editor-preview styling for the Poster card variant (CSP-115).
+   Public rendering is handled by the Next.js frontend (CSP-108). */
+.csp-card-variant-poster {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 0.375rem;
+  box-shadow: none;
+  background: transparent;
+}
+
+.csp-card-variant-poster .paragraph-su-card-media,
+.csp-card-variant-poster [class*="card_image"] {
+  flex: 1 1 45%;
+  min-width: 12rem;
+}
+
+.csp-card-variant-poster .paragraph-su-card-body,
+.csp-card-variant-poster [class*="card_body"] {
+  flex: 1 1 45%;
+  min-width: 12rem;
+  padding: 1.5rem;
+  border-radius: 20px;
+  color: #fff;
+  background: var(--csp-poster-bg, #8c1515);
+}

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/css/card-poster-preview.css
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/css/card-poster-preview.css
@@ -2,14 +2,9 @@
    This approximates the design inside the Layout Paragraphs builder
    so editors can tell a Poster card apart from a default card.
    The Next.js frontend owns the real presentation.
-
-   CspHelperHooks::uiPatternsInfoAlter() registers a "poster" variant on the
-   card pattern and CspCardBehaviors::view() selects it, so the card carries
-   the CSP-owned "su-card--poster" modifier class.
-*/
-
-/* Image beside the color panel. */
-.su-card.su-card--poster {
+ */
+.su-card.csp-card-variant-poster,
+.csp-card-variant-poster .su-card {
   display: grid;
   grid-template-columns: 100%;
   gap: 2.31rem;
@@ -19,13 +14,15 @@
 }
 
 @media only screen and (min-width: 576px) {
-  .su-card.su-card--poster {
+  .su-card.csp-card-variant-poster,
+  .csp-card-variant-poster .su-card {
     grid-template-columns: 1fr 2fr;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .su-card.su-card--poster {
+  .su-card.csp-card-variant-poster,
+  .csp-card-variant-poster .su-card {
     grid-template-columns: 1fr 1fr;
     gap: 2.6rem;
   }
@@ -33,32 +30,59 @@
 
 /* The grid stretches the media wrapper to the row height already; these pass
    that height down to the image so it matches the color panel. */
-.su-card--poster .media-entity-wrapper,
-.su-card--poster .media-entity-wrapper > *,
-.su-card--poster picture {
+.csp-card-variant-poster .media-entity-wrapper,
+.csp-card-variant-poster .media-entity-wrapper > *,
+.csp-card-variant-poster picture {
   display: block;
   height: 100%;
 }
 
-.su-card--poster img {
+.csp-card-variant-poster img {
   width: 100%;
   height: 100%;
   border-radius: 12px;
   object-fit: cover;
 }
 
-.su-card--poster .su-card__contents {
+/* Cardinal red is the panel default, used until a color is picked. */
+.csp-card-variant-poster .su-card__contents {
   padding: 1em;
   border-radius: 12px;
-  color: var(--csp-poster-fg, #fff);
-  background: var(--csp-poster-bg, #8c1515);
+  background: #8c1515;
+  color: #fff;
+}
+
+.csp-card-variant-poster .su-card__contents a {
+  color: #fff;
 }
 
 /* Keep the superhead from riding up out of the top of the color panel. */
-.su-card--poster .su-card__contents > :first-child {
+.csp-card-variant-poster .su-card__contents > :first-child {
   margin-top: 0;
 }
 
-.su-card--poster .su-card__contents a {
-  color: var(--csp-poster-fg, #fff);
+/* One rule per swatch offered by the color_field_widget_box widget. */
+.csp-card-bg-007c92 .su-card__contents {
+  background: #007c92;
+}
+
+.csp-card-bg-620059 .su-card__contents {
+  background: #620059;
+}
+
+.csp-card-bg-175e54 .su-card__contents {
+  background: #175e54;
+}
+
+.csp-card-bg-2e2d29 .su-card__contents {
+  background: #2e2d29;
+}
+
+.csp-card-bg-f4f4f4 .su-card__contents {
+  background: #f4f4f4;
+  color: #2e2d29;
+}
+
+.csp-card-bg-f4f4f4 .su-card__contents a {
+  color: #2e2d29;
 }

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/src/Hook/CspHelperHooks.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/src/Hook/CspHelperHooks.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\csp_helper\Hook;
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 
 /**
@@ -29,6 +30,33 @@ class CspHelperHooks {
         'template' => 'paragraph--csp-course-card-instructor',
       ],
     ];
+  }
+
+  /**
+   * Implements hook_paragraphs_behavior_info_alter().
+   *
+   * Swap the upstream card behavior for the CSP subclass so the Poster
+   * variant option is available.
+   */
+  #[Hook('paragraphs_behavior_info_alter')]
+  public function paragraphsBehaviorInfoAlter(array &$behaviors): void {
+    if (isset($behaviors['su_card_styles'])) {
+      $behaviors['su_card_styles']['class'] = 'Drupal\\csp_helper\\Plugin\\paragraphs\\Behavior\\CspCardBehaviors';
+    }
+  }
+
+  /**
+   * Implements hook_field_widget_single_element_form_alter().
+   *
+   * Show the poster background color field only when the card's variant is
+   * set to Poster.
+   */
+  #[Hook('field_widget_single_element_form_alter')]
+  public function fieldWidgetSingleElementFormAlter(array &$element, FormStateInterface $form_state, array $context): void {
+    if ($context['items']->getFieldDefinition()->getName() === 'csp_card_bg_color') {
+      $selector = '[name="behavior_plugins[su_card_styles][csp_card_variant]"]';
+      $element['#states']['visible'][$selector] = ['value' => 'poster'];
+    }
   }
 
 }

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/src/Hook/CspHelperHooks.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/src/Hook/CspHelperHooks.php
@@ -49,28 +49,6 @@ class CspHelperHooks {
   }
 
   /**
-   * Implements hook_ui_patterns_info_alter().
-   *
-   * Registers a "Poster" variant on the card pattern so the CSP poster
-   * styling gets a modifier class of its own.
-   */
-  #[Hook('ui_patterns_info_alter')]
-  public function uiPatternsInfoAlter(array &$definitions): void {
-    foreach ($definitions as $definition) {
-      if ($definition->id() === 'card') {
-        $definition->setVariants([
-          'poster' => [
-            'label' => 'Poster',
-            'description' => 'CSP poster card: image beside a solid color panel.',
-            'modifier_class' => 'su-card--poster',
-          ],
-        ]);
-        break;
-      }
-    }
-  }
-
-  /**
    * Implements hook_field_widget_single_element_form_alter().
    *
    * Show the poster background color field only when the card's variant is

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/src/Hook/CspHelperHooks.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/src/Hook/CspHelperHooks.php
@@ -49,6 +49,28 @@ class CspHelperHooks {
   }
 
   /**
+   * Implements hook_ui_patterns_info_alter().
+   *
+   * Registers a "Poster" variant on the card pattern so the CSP poster
+   * styling gets a modifier class of its own.
+   */
+  #[Hook('ui_patterns_info_alter')]
+  public function uiPatternsInfoAlter(array &$definitions): void {
+    foreach ($definitions as $definition) {
+      if ($definition->id() === 'card') {
+        $definition->setVariants([
+          'poster' => [
+            'label' => 'Poster',
+            'description' => 'CSP poster card: image beside a solid color panel.',
+            'modifier_class' => 'su-card--poster',
+          ],
+        ]);
+        break;
+      }
+    }
+  }
+
+  /**
    * Implements hook_field_widget_single_element_form_alter().
    *
    * Show the poster background color field only when the card's variant is

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/src/Plugin/paragraphs/Behavior/CspCardBehaviors.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/src/Plugin/paragraphs/Behavior/CspCardBehaviors.php
@@ -46,7 +46,7 @@ class CspCardBehaviors extends CardBehavior {
       $hex = $paragraph->get('csp_card_bg_color')->first()->get('color')->getString();
       if ($hex) {
         $style = $build['#attributes']['style'] ?? '';
-        $build['#attributes']['style'] = $style . '--csp-poster-bg:' . $hex . ';';
+        $build['#attributes']['style'] = $style . '--csp-poster-bg:#' . ltrim($hex, '#') . ';';
       }
     }
   }

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/src/Plugin/paragraphs/Behavior/CspCardBehaviors.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/src/Plugin/paragraphs/Behavior/CspCardBehaviors.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\csp_helper\Plugin\paragraphs\Behavior;
+
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\paragraphs\ParagraphInterface;
+use Drupal\stanford_paragraph_card\Plugin\paragraphs\Behavior\CardBehavior;
+
+/**
+ * Adds CSP-specific style options (Poster variant) to the card behavior.
+ */
+class CspCardBehaviors extends CardBehavior {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function buildBehaviorForm(ParagraphInterface $paragraph, array &$form, FormStateInterface $form_state): array {
+    $element = parent::buildBehaviorForm($paragraph, $form, $form_state);
+    $element['csp_card_variant'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Card variant'),
+      '#empty_option' => $this->t('Default'),
+      '#options' => [
+        'poster' => $this->t('Poster'),
+      ],
+      '#default_value' => $paragraph->getBehaviorSetting('su_card_styles', 'csp_card_variant'),
+    ];
+    return $element;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function view(array &$build, ParagraphInterface $paragraph, EntityViewDisplayInterface $display, $view_mode): void {
+    parent::view($build, $paragraph, $display, $view_mode);
+
+    if ($paragraph->getBehaviorSetting('su_card_styles', 'csp_card_variant') !== 'poster') {
+      return;
+    }
+
+    $build['#attributes']['class'][] = 'csp-card-variant-poster';
+    $build['#attached']['library'][] = 'csp_helper/card_poster_preview';
+
+    if ($paragraph->hasField('csp_card_bg_color') && !$paragraph->get('csp_card_bg_color')->isEmpty()) {
+      $hex = $paragraph->get('csp_card_bg_color')->first()->get('color')->getString();
+      if ($hex) {
+        $style = $build['#attributes']['style'] ?? '';
+        $build['#attributes']['style'] = $style . '--csp-poster-bg:' . $hex . ';';
+      }
+    }
+  }
+
+}

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/src/Plugin/paragraphs/Behavior/CspCardBehaviors.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/src/Plugin/paragraphs/Behavior/CspCardBehaviors.php
@@ -42,9 +42,10 @@ class CspCardBehaviors extends CardBehavior {
     $build['#attributes']['class'][] = 'csp-card-variant-poster';
     $build['#attached']['library'][] = 'csp_helper/card_poster_preview';
 
-    // Render through Decanter's horizontal card by switching the ui_patterns
-    // variant, which adds the "su-card--horizontal" modifier class. 
-    $build['#ds_configuration']['layout']['settings']['pattern']['variant'] = 'postcard';
+    // Switch to the "poster" ui_patterns variant registered by
+    // CspHelperHooks::uiPatternsInfoAlter(), which adds the CSP-owned
+    // "su-card--poster" modifier class that card-poster-preview.css targets.
+    $build['#ds_configuration']['layout']['settings']['pattern']['variant'] = 'poster';
 
     if ($paragraph->hasField('csp_card_bg_color') && !$paragraph->get('csp_card_bg_color')->isEmpty()) {
       $hex = $paragraph->get('csp_card_bg_color')->first()->get('color')->getString();
@@ -67,7 +68,15 @@ class CspCardBehaviors extends CardBehavior {
    *   Either '#fff' or '#2e2d29'.
    */
   private static function contrastColor(string $hex): string {
-    return strtolower($hex) === 'f4f4f4' ? '#2e2d29' : '#fff';
+    $channels = [];
+    foreach (sscanf($hex, '%2x%2x%2x') ?: [0, 0, 0] as $value) {
+      $channel = $value / 255;
+      $channels[] = $channel <= 0.04045 ? $channel / 12.92 : (($channel + 0.055) / 1.055) ** 2.4;
+    }
+    // WCAG relative luminance. 0.179 is the crossover point at which white and
+    // dark text give equal contrast against the background.
+    $luminance = 0.2126 * $channels[0] + 0.7152 * $channels[1] + 0.0722 * $channels[2];
+    return $luminance > 0.179 ? '#2e2d29' : '#fff';
   }
 
 }

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/src/Plugin/paragraphs/Behavior/CspCardBehaviors.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/src/Plugin/paragraphs/Behavior/CspCardBehaviors.php
@@ -42,13 +42,32 @@ class CspCardBehaviors extends CardBehavior {
     $build['#attributes']['class'][] = 'csp-card-variant-poster';
     $build['#attached']['library'][] = 'csp_helper/card_poster_preview';
 
+    // Render through Decanter's horizontal card by switching the ui_patterns
+    // variant, which adds the "su-card--horizontal" modifier class. 
+    $build['#ds_configuration']['layout']['settings']['pattern']['variant'] = 'postcard';
+
     if ($paragraph->hasField('csp_card_bg_color') && !$paragraph->get('csp_card_bg_color')->isEmpty()) {
       $hex = $paragraph->get('csp_card_bg_color')->first()->get('color')->getString();
       if ($hex) {
+        $hex = ltrim($hex, '#');
         $style = $build['#attributes']['style'] ?? '';
-        $build['#attributes']['style'] = $style . '--csp-poster-bg:#' . ltrim($hex, '#') . ';';
+        $build['#attributes']['style'] = $style . '--csp-poster-bg:#' . $hex . ';'
+          . '--csp-poster-fg:' . self::contrastColor($hex) . ';';
       }
     }
+  }
+
+  /**
+   * Picks a readable text color for a poster background.
+   *
+   * @param string $hex
+   *   A background color as a six-digit hex string, without a leading "#".
+   *
+   * @return string
+   *   Either '#fff' or '#2e2d29'.
+   */
+  private static function contrastColor(string $hex): string {
+    return strtolower($hex) === 'f4f4f4' ? '#2e2d29' : '#fff';
   }
 
 }

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/src/Plugin/paragraphs/Behavior/CspCardBehaviors.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/src/Plugin/paragraphs/Behavior/CspCardBehaviors.php
@@ -41,42 +41,10 @@ class CspCardBehaviors extends CardBehavior {
 
     $build['#attributes']['class'][] = 'csp-card-variant-poster';
     $build['#attached']['library'][] = 'csp_helper/card_poster_preview';
-
-    // Switch to the "poster" ui_patterns variant registered by
-    // CspHelperHooks::uiPatternsInfoAlter(), which adds the CSP-owned
-    // "su-card--poster" modifier class that card-poster-preview.css targets.
-    $build['#ds_configuration']['layout']['settings']['pattern']['variant'] = 'poster';
-
-    if ($paragraph->hasField('csp_card_bg_color') && !$paragraph->get('csp_card_bg_color')->isEmpty()) {
-      $hex = $paragraph->get('csp_card_bg_color')->first()->get('color')->getString();
-      if ($hex) {
-        $hex = ltrim($hex, '#');
-        $style = $build['#attributes']['style'] ?? '';
-        $build['#attributes']['style'] = $style . '--csp-poster-bg:#' . $hex . ';'
-          . '--csp-poster-fg:' . self::contrastColor($hex) . ';';
-      }
+    
+    if ($bg_color = $paragraph->get('csp_card_bg_color')?->getString()) {
+      $build['#attributes']['class'][] = "csp-card-bg-$bg_color";
     }
-  }
-
-  /**
-   * Picks a readable text color for a poster background.
-   *
-   * @param string $hex
-   *   A background color as a six-digit hex string, without a leading "#".
-   *
-   * @return string
-   *   Either '#fff' or '#2e2d29'.
-   */
-  private static function contrastColor(string $hex): string {
-    $channels = [];
-    foreach (sscanf($hex, '%2x%2x%2x') ?: [0, 0, 0] as $value) {
-      $channel = $value / 255;
-      $channels[] = $channel <= 0.04045 ? $channel / 12.92 : (($channel + 0.055) / 1.055) ** 2.4;
-    }
-    // WCAG relative luminance. 0.179 is the crossover point at which white and
-    // dark text give equal contrast against the background.
-    $luminance = 0.2126 * $channels[0] + 0.7152 * $channels[1] + 0.0722 * $channels[2];
-    return $luminance > 0.179 ? '#2e2d29' : '#fff';
   }
 
 }

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Hook/CspHelperHooksTest.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Hook/CspHelperHooksTest.php
@@ -13,6 +13,7 @@ use Drupal\csp_helper\Layouts\CspOneColumn;
 use Drupal\csp_helper\Layouts\CspThreeColumn;
 use Drupal\csp_helper\Layouts\CspTwoColumn;
 use Drupal\Tests\UnitTestCase;
+use Drupal\ui_patterns\Definition\PatternDefinition;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
@@ -54,6 +55,43 @@ class CspHelperHooksTest extends UnitTestCase {
     $hooks->fieldWidgetSingleElementFormAlter($element, $form_state, $context);
 
     $this->assertArrayNotHasKey('#states', $element);
+  }
+
+  /**
+   * The card pattern gains a "poster" variant with its own modifier class.
+   *
+   * jumpstart_ui_preprocess() reads the modifier class out of the definition
+   * as an array, so assert against toArray() rather than the object.
+   */
+  public function testPosterVariantIsRegistered(): void {
+    $definitions = [
+      'yaml:card' => new PatternDefinition([
+        'id' => 'card',
+        'variants' => ['postcard' => ['label' => 'Postcard', 'modifier_class' => 'su-card--horizontal']],
+      ]),
+      'yaml:stat_card' => new PatternDefinition(['id' => 'stat_card']),
+    ];
+
+    (new CspHelperHooks())->uiPatternsInfoAlter($definitions);
+
+    $variants = $definitions['yaml:card']->toArray()['variants'];
+    $this->assertSame('su-card--poster', $variants['poster']['modifier_class']);
+    $this->assertSame('Poster', $variants['poster']['label']);
+    // Upstream variants must survive.
+    $this->assertSame('su-card--horizontal', $variants['postcard']['modifier_class']);
+    // A pattern whose id merely contains "card" must be left alone.
+    $this->assertArrayNotHasKey('poster', $definitions['yaml:stat_card']->toArray()['variants']);
+  }
+
+  /**
+   * The hook is a no-op when the card pattern is not present.
+   */
+  public function testPosterVariantWithoutCardPattern(): void {
+    $definitions = ['yaml:quote' => new PatternDefinition(['id' => 'quote'])];
+
+    (new CspHelperHooks())->uiPatternsInfoAlter($definitions);
+
+    $this->assertArrayNotHasKey('poster', $definitions['yaml:quote']->toArray()['variants']);
   }
 
   /**

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Hook/CspHelperHooksTest.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Hook/CspHelperHooksTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\Tests\csp_helper\Unit\Hook;
+
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\csp_helper\Hook\CspHelperHooks;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\csp_helper\Hook\CspHelperHooks
+ * @group csp_helper
+ */
+class CspHelperHooksTest extends UnitTestCase {
+
+  private function makeContext(string $field_name): array {
+    $definition = $this->createMock(FieldDefinitionInterface::class);
+    $definition->method('getName')->willReturn($field_name);
+    $items = $this->createMock(FieldItemListInterface::class);
+    $items->method('getFieldDefinition')->willReturn($definition);
+    return ['items' => $items];
+  }
+
+  public function testColorFieldGetsStates(): void {
+    $hooks = new CspHelperHooks();
+    $element = [];
+    $form_state = new FormState();
+    $context = $this->makeContext('csp_card_bg_color');
+
+    $hooks->fieldWidgetSingleElementFormAlter($element, $form_state, $context);
+
+    $selector = '[name="behavior_plugins[su_card_styles][csp_card_variant]"]';
+    $this->assertArrayHasKey('#states', $element);
+    $this->assertSame(
+      ['value' => 'poster'],
+      $element['#states']['visible'][$selector]
+    );
+  }
+
+  public function testOtherFieldUntouched(): void {
+    $hooks = new CspHelperHooks();
+    $element = [];
+    $form_state = new FormState();
+    $context = $this->makeContext('su_card_body');
+
+    $hooks->fieldWidgetSingleElementFormAlter($element, $form_state, $context);
+
+    $this->assertArrayNotHasKey('#states', $element);
+  }
+
+}

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Hook/CspHelperHooksTest.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Hook/CspHelperHooksTest.php
@@ -13,7 +13,6 @@ use Drupal\csp_helper\Layouts\CspOneColumn;
 use Drupal\csp_helper\Layouts\CspThreeColumn;
 use Drupal\csp_helper\Layouts\CspTwoColumn;
 use Drupal\Tests\UnitTestCase;
-use Drupal\ui_patterns\Definition\PatternDefinition;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
@@ -55,43 +54,6 @@ class CspHelperHooksTest extends UnitTestCase {
     $hooks->fieldWidgetSingleElementFormAlter($element, $form_state, $context);
 
     $this->assertArrayNotHasKey('#states', $element);
-  }
-
-  /**
-   * The card pattern gains a "poster" variant with its own modifier class.
-   *
-   * jumpstart_ui_preprocess() reads the modifier class out of the definition
-   * as an array, so assert against toArray() rather than the object.
-   */
-  public function testPosterVariantIsRegistered(): void {
-    $definitions = [
-      'yaml:card' => new PatternDefinition([
-        'id' => 'card',
-        'variants' => ['postcard' => ['label' => 'Postcard', 'modifier_class' => 'su-card--horizontal']],
-      ]),
-      'yaml:stat_card' => new PatternDefinition(['id' => 'stat_card']),
-    ];
-
-    (new CspHelperHooks())->uiPatternsInfoAlter($definitions);
-
-    $variants = $definitions['yaml:card']->toArray()['variants'];
-    $this->assertSame('su-card--poster', $variants['poster']['modifier_class']);
-    $this->assertSame('Poster', $variants['poster']['label']);
-    // Upstream variants must survive.
-    $this->assertSame('su-card--horizontal', $variants['postcard']['modifier_class']);
-    // A pattern whose id merely contains "card" must be left alone.
-    $this->assertArrayNotHasKey('poster', $definitions['yaml:stat_card']->toArray()['variants']);
-  }
-
-  /**
-   * The hook is a no-op when the card pattern is not present.
-   */
-  public function testPosterVariantWithoutCardPattern(): void {
-    $definitions = ['yaml:quote' => new PatternDefinition(['id' => 'quote'])];
-
-    (new CspHelperHooks())->uiPatternsInfoAlter($definitions);
-
-    $this->assertArrayNotHasKey('poster', $definitions['yaml:quote']->toArray()['variants']);
   }
 
   /**

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Plugin/paragraphs/Behavior/CspCardBehaviorsTest.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Plugin/paragraphs/Behavior/CspCardBehaviorsTest.php
@@ -61,9 +61,9 @@ class CspCardBehaviorsTest extends UnitTestCase {
         return $key === 'csp_card_variant' ? 'poster' : NULL;
       });
 
-    // Mock the color field: get('csp_card_bg_color')->first()->get('color')->getString() === '#620059'
+    // Mock the color field.
     $color_prop = $this->createMock(TypedDataInterface::class);
-    $color_prop->method('getString')->willReturn('#620059');
+    $color_prop->method('getString')->willReturn('620059');
     $item = $this->createMock(ColorFieldType::class);
     $item->method('get')->with('color')->willReturn($color_prop);
     $list = $this->createMock(FieldItemListInterface::class);

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Plugin/paragraphs/Behavior/CspCardBehaviorsTest.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Plugin/paragraphs/Behavior/CspCardBehaviorsTest.php
@@ -13,6 +13,7 @@ use Drupal\csp_helper\Plugin\paragraphs\Behavior\CspCardBehaviors;
 use Drupal\paragraphs\Entity\ParagraphsType;
 use Drupal\paragraphs\ParagraphInterface;
 use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @coversDefaultClass \Drupal\csp_helper\Plugin\paragraphs\Behavior\CspCardBehaviors
@@ -51,19 +52,84 @@ class CspCardBehaviorsTest extends UnitTestCase {
     $this->assertArrayHasKey('heading', $element);
   }
 
-  public function testPosterViewAddsClassAndColor(): void {
+  #[DataProvider('providerPosterBackgroundColors')]
+  public function testPosterViewAddsClassAndColor(string $hex, string $expected_fg): void {
     $field_manager = $this->createMock(EntityFieldManagerInterface::class);
     $behavior = new CspCardBehaviors([], '', [], $field_manager);
 
+    $paragraph = $this->mockPosterParagraph($hex);
+    $display = $this->createMock(EntityViewDisplayInterface::class);
+    $build = [];
+    $behavior->view($build, $paragraph, $display, 'default');
+
+    $this->assertContains('csp-card-variant-poster', $build['#attributes']['class']);
+    $this->assertStringContainsString("--csp-poster-bg:#$hex", $build['#attributes']['style']);
+    $this->assertStringContainsString("--csp-poster-fg:$expected_fg", $build['#attributes']['style']);
+    $this->assertContains('csp_helper/card_poster_preview', $build['#attached']['library']);
+  }
+
+  public function testPosterViewSwitchesToHorizontalPattern(): void {
+    $field_manager = $this->createMock(EntityFieldManagerInterface::class);
+    $behavior = new CspCardBehaviors([], '', [], $field_manager);
+
+    $paragraph = $this->mockPosterParagraph('8c1515');
+    $display = $this->createMock(EntityViewDisplayInterface::class);
+    $build = [];
+    $behavior->view($build, $paragraph, $display, 'default');
+
+    // "postcard" carries Decanter's su-card--horizontal modifier class, which
+    // is what lays the card out side by side.
+    $this->assertSame(
+      'postcard',
+      $build['#ds_configuration']['layout']['settings']['pattern']['variant']
+    );
+  }
+
+  public function testNonPosterViewIsUntouched(): void {
+    $field_manager = $this->createMock(EntityFieldManagerInterface::class);
+    $behavior = new CspCardBehaviors([], '', [], $field_manager);
+
+    $paragraph = $this->createMock(ParagraphInterface::class);
+    $paragraph->method('getBehaviorSetting')->willReturn(NULL);
+
+    $display = $this->createMock(EntityViewDisplayInterface::class);
+    $build = [];
+    $behavior->view($build, $paragraph, $display, 'default');
+
+    $this->assertArrayNotHasKey('#ds_configuration', $build);
+    $this->assertArrayNotHasKey('#attributes', $build);
+  }
+
+  /**
+   * The six colors offered by the color_field_widget_box widget.
+   *
+   * Mirrors the "default_colors" setting on the csp_card_bg_color widget in
+   * config_split.patch.core.entity_form_display.paragraph.stanford_card.default.
+   */
+  public static function providerPosterBackgroundColors(): array {
+    return [
+      'cardinal red' => ['8c1515', '#fff'],
+      'lagunita blue' => ['007c92', '#fff'],
+      'plum' => ['620059', '#fff'],
+      'palo verde' => ['175e54', '#fff'],
+      'black' => ['2e2d29', '#fff'],
+      // The one light swatch, which needs dark text to stay readable.
+      'fog light' => ['f4f4f4', '#2e2d29'],
+    ];
+  }
+
+  /**
+   * Builds a Poster-variant paragraph with the given background color.
+   */
+  private function mockPosterParagraph(string $hex): ParagraphInterface {
     $paragraph = $this->createMock(ParagraphInterface::class);
     $paragraph->method('getBehaviorSetting')
       ->willReturnCallback(function ($module, $key) {
         return $key === 'csp_card_variant' ? 'poster' : NULL;
       });
 
-    // Mock the color field.
     $color_prop = $this->createMock(TypedDataInterface::class);
-    $color_prop->method('getString')->willReturn('620059');
+    $color_prop->method('getString')->willReturn($hex);
     $item = $this->createMock(ColorFieldType::class);
     $item->method('get')->with('color')->willReturn($color_prop);
     $list = $this->createMock(FieldItemListInterface::class);
@@ -72,13 +138,7 @@ class CspCardBehaviorsTest extends UnitTestCase {
     $paragraph->method('hasField')->with('csp_card_bg_color')->willReturn(TRUE);
     $paragraph->method('get')->with('csp_card_bg_color')->willReturn($list);
 
-    $display = $this->createMock(EntityViewDisplayInterface::class);
-    $build = [];
-    $behavior->view($build, $paragraph, $display, 'default');
-
-    $this->assertContains('csp-card-variant-poster', $build['#attributes']['class']);
-    $this->assertStringContainsString('--csp-poster-bg:#620059', $build['#attributes']['style']);
-    $this->assertContains('csp_helper/card_poster_preview', $build['#attached']['library']);
+    return $paragraph;
   }
 
 }

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Plugin/paragraphs/Behavior/CspCardBehaviorsTest.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Plugin/paragraphs/Behavior/CspCardBehaviorsTest.php
@@ -68,7 +68,7 @@ class CspCardBehaviorsTest extends UnitTestCase {
     $this->assertContains('csp_helper/card_poster_preview', $build['#attached']['library']);
   }
 
-  public function testPosterViewSwitchesToHorizontalPattern(): void {
+  public function testPosterViewSelectsPosterPattern(): void {
     $field_manager = $this->createMock(EntityFieldManagerInterface::class);
     $behavior = new CspCardBehaviors([], '', [], $field_manager);
 
@@ -77,10 +77,11 @@ class CspCardBehaviorsTest extends UnitTestCase {
     $build = [];
     $behavior->view($build, $paragraph, $display, 'default');
 
-    // "postcard" carries Decanter's su-card--horizontal modifier class, which
-    // is what lays the card out side by side.
+    // "poster" is the CSP-owned variant registered by
+    // CspHelperHooks::uiPatternsInfoAlter(); it carries the su-card--poster
+    // modifier class that card-poster-preview.css lays out.
     $this->assertSame(
-      'postcard',
+      'poster',
       $build['#ds_configuration']['layout']['settings']['pattern']['variant']
     );
   }
@@ -101,10 +102,14 @@ class CspCardBehaviorsTest extends UnitTestCase {
   }
 
   /**
-   * The six colors offered by the color_field_widget_box widget.
+   * Background colors and the text color that stays readable on each.
    *
-   * Mirrors the "default_colors" setting on the csp_card_bg_color widget in
-   * config_split.patch.core.entity_form_display.paragraph.stanford_card.default.
+   * The first six are the swatches currently offered by the
+   * color_field_widget_box widget. The rest are not in that palette on
+   * purpose: the text color is derived from the background's relative
+   * luminance, so a site builder can edit the widget's "default_colors"
+   * setting, or a value can arrive through the widget's text input, without
+   * producing unreadable text.
    */
   public static function providerPosterBackgroundColors(): array {
     return [
@@ -115,6 +120,13 @@ class CspCardBehaviorsTest extends UnitTestCase {
       'black' => ['2e2d29', '#fff'],
       // The one light swatch, which needs dark text to stay readable.
       'fog light' => ['f4f4f4', '#2e2d29'],
+      // Outside the current palette.
+      'white' => ['ffffff', '#2e2d29'],
+      'yellow' => ['ffff00', '#2e2d29'],
+      'mid grey' => ['c2c2c2', '#2e2d29'],
+      'pale cyan' => ['9fe1e7', '#2e2d29'],
+      'navy' => ['00205b', '#fff'],
+      'uppercase hex' => ['8C1515', '#fff'],
     ];
   }
 

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Plugin/paragraphs/Behavior/CspCardBehaviorsTest.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Plugin/paragraphs/Behavior/CspCardBehaviorsTest.php
@@ -7,8 +7,6 @@ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormState;
-use Drupal\Core\TypedData\TypedDataInterface;
-use Drupal\color_field\Plugin\Field\FieldType\ColorFieldType;
 use Drupal\csp_helper\Plugin\paragraphs\Behavior\CspCardBehaviors;
 use Drupal\paragraphs\Entity\ParagraphsType;
 use Drupal\paragraphs\ParagraphInterface;
@@ -53,7 +51,7 @@ class CspCardBehaviorsTest extends UnitTestCase {
   }
 
   #[DataProvider('providerPosterBackgroundColors')]
-  public function testPosterViewAddsClassAndColor(string $hex, string $expected_fg): void {
+  public function testPosterViewAddsVariantAndColorClass(string $hex): void {
     $field_manager = $this->createMock(EntityFieldManagerInterface::class);
     $behavior = new CspCardBehaviors([], '', [], $field_manager);
 
@@ -63,27 +61,24 @@ class CspCardBehaviorsTest extends UnitTestCase {
     $behavior->view($build, $paragraph, $display, 'default');
 
     $this->assertContains('csp-card-variant-poster', $build['#attributes']['class']);
-    $this->assertStringContainsString("--csp-poster-bg:#$hex", $build['#attributes']['style']);
-    $this->assertStringContainsString("--csp-poster-fg:$expected_fg", $build['#attributes']['style']);
+    $this->assertContains("csp-card-bg-$hex", $build['#attributes']['class']);
+    $this->assertArrayNotHasKey('style', $build['#attributes']);
     $this->assertContains('csp_helper/card_poster_preview', $build['#attached']['library']);
   }
 
-  public function testPosterViewSelectsPosterPattern(): void {
+  /**
+   * With no color picked the panel falls back to the default set in CSS.
+   */
+  public function testPosterViewWithoutColor(): void {
     $field_manager = $this->createMock(EntityFieldManagerInterface::class);
     $behavior = new CspCardBehaviors([], '', [], $field_manager);
 
-    $paragraph = $this->mockPosterParagraph('8c1515');
+    $paragraph = $this->mockPosterParagraph('');
     $display = $this->createMock(EntityViewDisplayInterface::class);
     $build = [];
     $behavior->view($build, $paragraph, $display, 'default');
 
-    // "poster" is the CSP-owned variant registered by
-    // CspHelperHooks::uiPatternsInfoAlter(); it carries the su-card--poster
-    // modifier class that card-poster-preview.css lays out.
-    $this->assertSame(
-      'poster',
-      $build['#ds_configuration']['layout']['settings']['pattern']['variant']
-    );
+    $this->assertSame(['csp-card-variant-poster'], $build['#attributes']['class']);
   }
 
   public function testNonPosterViewIsUntouched(): void {
@@ -97,36 +92,21 @@ class CspCardBehaviorsTest extends UnitTestCase {
     $build = [];
     $behavior->view($build, $paragraph, $display, 'default');
 
-    $this->assertArrayNotHasKey('#ds_configuration', $build);
     $this->assertArrayNotHasKey('#attributes', $build);
   }
 
   /**
-   * Background colors and the text color that stays readable on each.
-   *
-   * The first six are the swatches currently offered by the
-   * color_field_widget_box widget. The rest are not in that palette on
-   * purpose: the text color is derived from the background's relative
-   * luminance, so a site builder can edit the widget's "default_colors"
-   * setting, or a value can arrive through the widget's text input, without
-   * producing unreadable text.
+   * The swatches offered by the color_field_widget_box widget.
+
    */
   public static function providerPosterBackgroundColors(): array {
     return [
-      'cardinal red' => ['8c1515', '#fff'],
-      'lagunita blue' => ['007c92', '#fff'],
-      'plum' => ['620059', '#fff'],
-      'palo verde' => ['175e54', '#fff'],
-      'black' => ['2e2d29', '#fff'],
-      // The one light swatch, which needs dark text to stay readable.
-      'fog light' => ['f4f4f4', '#2e2d29'],
-      // Outside the current palette.
-      'white' => ['ffffff', '#2e2d29'],
-      'yellow' => ['ffff00', '#2e2d29'],
-      'mid grey' => ['c2c2c2', '#2e2d29'],
-      'pale cyan' => ['9fe1e7', '#2e2d29'],
-      'navy' => ['00205b', '#fff'],
-      'uppercase hex' => ['8C1515', '#fff'],
+      'cardinal red' => ['8c1515'],
+      'lagunita blue' => ['007c92'],
+      'plum' => ['620059'],
+      'palo verde' => ['175e54'],
+      'black' => ['2e2d29'],
+      'fog light' => ['f4f4f4'],
     ];
   }
 
@@ -140,14 +120,8 @@ class CspCardBehaviorsTest extends UnitTestCase {
         return $key === 'csp_card_variant' ? 'poster' : NULL;
       });
 
-    $color_prop = $this->createMock(TypedDataInterface::class);
-    $color_prop->method('getString')->willReturn($hex);
-    $item = $this->createMock(ColorFieldType::class);
-    $item->method('get')->with('color')->willReturn($color_prop);
     $list = $this->createMock(FieldItemListInterface::class);
-    $list->method('isEmpty')->willReturn(FALSE);
-    $list->method('first')->willReturn($item);
-    $paragraph->method('hasField')->with('csp_card_bg_color')->willReturn(TRUE);
+    $list->method('getString')->willReturn($hex);
     $paragraph->method('get')->with('csp_card_bg_color')->willReturn($list);
 
     return $paragraph;

--- a/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Plugin/paragraphs/Behavior/CspCardBehaviorsTest.php
+++ b/docroot/profiles/lagunita/csp_profile/csp_helper/tests/src/Unit/Plugin/paragraphs/Behavior/CspCardBehaviorsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\Tests\csp_helper\Unit\Plugin\paragraphs\Behavior;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Drupal\color_field\Plugin\Field\FieldType\ColorFieldType;
+use Drupal\csp_helper\Plugin\paragraphs\Behavior\CspCardBehaviors;
+use Drupal\paragraphs\Entity\ParagraphsType;
+use Drupal\paragraphs\ParagraphInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\csp_helper\Plugin\paragraphs\Behavior\CspCardBehaviors
+ * @group csp_helper
+ */
+class CspCardBehaviorsTest extends UnitTestCase {
+
+  public function setUp(): void {
+    parent::setUp();
+    $container = new ContainerBuilder();
+    $container->set('string_translation', $this->getStringTranslationStub());
+    \Drupal::setContainer($container);
+  }
+
+  public function testAppliesToCard(): void {
+    $type = $this->createMock(ParagraphsType::class);
+    $type->method('id')->willReturn('stanford_card');
+    $this->assertTrue(CspCardBehaviors::isApplicable($type));
+  }
+
+  public function testVariantSelectAdded(): void {
+    $field_manager = $this->createMock(EntityFieldManagerInterface::class);
+    $behavior = new CspCardBehaviors([], '', [], $field_manager);
+
+    $paragraph = $this->createMock(ParagraphInterface::class);
+    $paragraph->method('getBehaviorSetting')->willReturn(NULL);
+
+    $form = [];
+    $form_state = new FormState();
+    $element = $behavior->buildBehaviorForm($paragraph, $form, $form_state);
+
+    $this->assertArrayHasKey('csp_card_variant', $element);
+    $this->assertSame('select', $element['csp_card_variant']['#type']);
+    $this->assertArrayHasKey('poster', $element['csp_card_variant']['#options']);
+    // Inherited base element still present.
+    $this->assertArrayHasKey('heading', $element);
+  }
+
+  public function testPosterViewAddsClassAndColor(): void {
+    $field_manager = $this->createMock(EntityFieldManagerInterface::class);
+    $behavior = new CspCardBehaviors([], '', [], $field_manager);
+
+    $paragraph = $this->createMock(ParagraphInterface::class);
+    $paragraph->method('getBehaviorSetting')
+      ->willReturnCallback(function ($module, $key) {
+        return $key === 'csp_card_variant' ? 'poster' : NULL;
+      });
+
+    // Mock the color field: get('csp_card_bg_color')->first()->get('color')->getString() === '#620059'
+    $color_prop = $this->createMock(TypedDataInterface::class);
+    $color_prop->method('getString')->willReturn('#620059');
+    $item = $this->createMock(ColorFieldType::class);
+    $item->method('get')->with('color')->willReturn($color_prop);
+    $list = $this->createMock(FieldItemListInterface::class);
+    $list->method('isEmpty')->willReturn(FALSE);
+    $list->method('first')->willReturn($item);
+    $paragraph->method('hasField')->with('csp_card_bg_color')->willReturn(TRUE);
+    $paragraph->method('get')->with('csp_card_bg_color')->willReturn($list);
+
+    $display = $this->createMock(EntityViewDisplayInterface::class);
+    $build = [];
+    $behavior->view($build, $paragraph, $display, 'default');
+
+    $this->assertContains('csp-card-variant-poster', $build['#attributes']['class']);
+    $this->assertStringContainsString('--csp-poster-bg:#620059', $build['#attributes']['style']);
+    $this->assertContains('csp_helper/card_poster_preview', $build['#attached']['library']);
+  }
+
+}

--- a/docroot/profiles/lagunita/csp_profile/tests/codeception/functional/Paragraphs/PosterCardCest.php
+++ b/docroot/profiles/lagunita/csp_profile/tests/codeception/functional/Paragraphs/PosterCardCest.php
@@ -25,12 +25,8 @@ class PosterCardCest {
   }
 
   /**
-   * Selecting the Poster variant renders the variant class and bg-color style.
+   * Selecting the Poster variant renders the variant and bg-color classes.
    *
-   * This exercises the whole integration the unit tests cannot: the
-   * paragraphs_behavior_info_alter() swap that surfaces the "Card variant"
-   * select, the field_widget #states that reveals the color field, and the
-   * CspCardBehaviors::view() output on render.
    */
   public function testPosterVariantRenders(FunctionalTester $I) {
     $header = $this->faker->words(3, TRUE);
@@ -79,8 +75,7 @@ class PosterCardCest {
     $I->click('Save', '#edit-actions');
     $I->canSee($node->label(), 'h1');
     $I->canSeeElement('.csp-card-variant-poster');
-    // The stored hex ("620059") is normalized back to a valid "#620059" color.
-    $I->canSeeElement('.csp-card-variant-poster[style*="--csp-poster-bg:#620059"]');
+    $I->canSeeElement('.csp-card-variant-poster.csp-card-bg-620059');
   }
 
 }

--- a/docroot/profiles/lagunita/csp_profile/tests/codeception/functional/Paragraphs/PosterCardCest.php
+++ b/docroot/profiles/lagunita/csp_profile/tests/codeception/functional/Paragraphs/PosterCardCest.php
@@ -1,0 +1,86 @@
+<?php
+
+use Codeception\Attribute as CodeceptionAttribute;
+use Faker\Factory;
+
+/**
+ * Tests the CSP "Poster" card variant added by csp_helper (CSP-115).
+ */
+#[CodeceptionAttribute\Group('paragraphs')]
+#[CodeceptionAttribute\Group('poster-card')]
+class PosterCardCest {
+
+  /**
+   * Faker service.
+   *
+   * @var \Faker\Generator
+   */
+  protected $faker;
+
+  /**
+   * Test constructor.
+   */
+  public function __construct() {
+    $this->faker = Factory::create();
+  }
+
+  /**
+   * Selecting the Poster variant renders the variant class and bg-color style.
+   *
+   * This exercises the whole integration the unit tests cannot: the
+   * paragraphs_behavior_info_alter() swap that surfaces the "Card variant"
+   * select, the field_widget #states that reveals the color field, and the
+   * CspCardBehaviors::view() output on render.
+   */
+  public function testPosterVariantRenders(FunctionalTester $I) {
+    $header = $this->faker->words(3, TRUE);
+    $body = $this->faker->words(6, TRUE);
+
+    /** @var \Drupal\paragraphs\ParagraphInterface $paragraph */
+    $paragraph = $I->createEntity([
+      'type' => 'stanford_card',
+      'su_card_header' => $header,
+      'su_card_body' => $body,
+    ], 'paragraph');
+
+    $node = $I->createEntity([
+      'type' => 'stanford_page',
+      'title' => $this->faker->words(4, TRUE),
+      'su_page_components' => [
+        'target_id' => $paragraph->id(),
+        'entity' => $paragraph,
+      ],
+    ]);
+
+    $I->logInWithRole('site_manager');
+
+    // Open the card in the Layout Paragraphs builder.
+    $I->amOnPage($node->toUrl('edit-form')->toString());
+    $I->scrollTo('.js-lpb-component', 0, -100);
+    $I->moveMouseOver('.js-lpb-component', 10, 10);
+    $I->click('Edit', '.lpb-controls');
+    $I->waitForText('Behaviors');
+    $I->clickWithLeftButton('.lpb-behavior-plugins summary');
+
+    // Choose the Poster variant. This is only available because the behavior
+    // class was swapped to CspCardBehaviors.
+    $I->selectOption('Card variant', 'Poster');
+
+    // The #states rule reveals the "Poster background color" field once Poster
+    // is selected; its box widget renders a swatch per configured color. Pick
+    // Stanford purple (#620059).
+    $I->waitForElementVisible('button.color_field_widget_box__square[color="#620059"]');
+    $I->click('button.color_field_widget_box__square[color="#620059"]');
+
+    $I->click('Save', '.ui-dialog-buttonpane');
+    $I->waitForElementNotVisible('.ui-dialog');
+
+    // Save the node and confirm the variant was applied on render.
+    $I->click('Save', '#edit-actions');
+    $I->canSee($node->label(), 'h1');
+    $I->canSeeElement('.csp-card-variant-poster');
+    // The stored hex ("620059") is normalized back to a valid "#620059" color.
+    $I->canSeeElement('.csp-card-variant-poster[style*="--csp-poster-bg:#620059"]');
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary

Adds a **Poster** card variant for CSP: a horizontal card with the image beside a solid-color panel holding the super-header, headline and body. Editors turn it on per-card from the **Behaviors** section of the card's Layout Paragraphs dialog, then pick the panel color from the Stanford brand palette.

Everything Drupal renders here is editor preview only, and the visitor-facing implementation will be a separate frontend PR.

### Behavior plugin

`hook_paragraphs_behavior_info_alter()` swaps upstream `stanford_paragraph_card`'s `CardBehavior` for `CspCardBehaviors`, which adds a "Card variant" select (Default / Poster) next to the existing heading and link-style options.

### New field

`csp_card_bg_color` (color_field) on `stanford_card`, in the csp config split. It uses the `color_field_widget_box` swatch widget preloaded with six colors, and `hook_field_widget_single_element_form_alter()` adds a `#states` rule so it
only appears once "Poster" is selected.

### ui_patterns variant

`hook_ui_patterns_info_alter()` registers a CSP-owned `poster` variant on the `card` pattern with the modifier class `su-card--poster`, and `CspCardBehaviors::view()` selects it at render time.

### Readable text, derived from background color

The panel's text color is computed from the background's WCAG relative luminance instead of being looked up per swatch, so editing the widget's `default_colors` setting or a value arriving through the widget's text input won't produce unreadable text.

### GraphQL

`csp_card_bg_color` is enabled in `graphql_compose.settings` so the frontend can read it. The variant selection itself already travels in the existing `behaviors` JSON that `getParagraphBehaviors()` parses.

# Review By (Date)

_TBD_

# Urgency

_TBD_

# Steps to Test

1. `drush cim` then `drush cr` 
2. Edit any page containing a Card component and open the card's edit dialog, then the **Behaviors** details element.
3. Set **Card variant** to **Poster**. The **Poster background color** swatches should appear; switch back to Default and they should hide again.
4. Pick a color, save the component, save the node.
5. The card should render horizontally, image beside a colored panel, with `class="su-card … su-card--poster"` and inline `--csp-poster-bg` / `--csp-poster-fg` custom properties.
6. Check contrast handling: the light swatch (`#f4f4f4`) should get dark text, the five dark swatches white text.

# Affected Projects or Products

- **csp only.** The field config lives in the csp split, and the behavior/pattern alters are in `csp_helper`, which no other site installs.
- Touches the shared `stanford_card` paragraph type (form display via a config_split patch) and the shared `card` ui_patterns definition, but only for this site.

# Testing

- Unit coverage for the behavior plugin and both new hooks
- `PosterCardCest` functional test exercises the full chain in the Layout Paragraphs builder 

# Associated Issues and/or People

- JIRA: CSP-115
- **Frontend dependency — this PR alone changes nothing for site visitors.** `SU-SWS/csp-nextjs` needs `cspCardBgColor` added to `FragmentParagraphStanfordCard` and a poster branch in `card-paragraph.tsx` keyed off `behaviors.su_card_styles.csp_card_variant`. No companion PR is open yet.

# See Also

- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
