### PR TITLE
CSP-136: Remove limit on instructors for faux course card

### DIFF
--- a/docroot/profiles/lagunita/csp_profile/config/sync/split/csp/field.field.paragraph.csp_faux_course_card.csp_course_card_instructors.yml
+++ b/docroot/profiles/lagunita/csp_profile/config/sync/split/csp/field.field.paragraph.csp_faux_course_card.csp_course_card_instructors.yml
@@ -13,7 +13,7 @@ field_name: csp_course_card_instructors
 entity_type: paragraph
 bundle: csp_faux_course_card
 label: Instructors
-description: 'Up to 3 instructor blocks.'
+description: 'Instructor blocks.'
 required: false
 translatable: false
 default_value: {  }
@@ -28,4 +28,55 @@ settings:
       csp_course_card_instructor:
         weight: 0
         enabled: true
+      csp_faux_course_card:
+        weight: 20
+        enabled: false
+      stanford_accordion:
+        weight: 21
+        enabled: false
+      stanford_banner:
+        weight: 22
+        enabled: false
+      stanford_card:
+        weight: 23
+        enabled: false
+      stanford_entity:
+        weight: 24
+        enabled: false
+      stanford_faq:
+        weight: 25
+        enabled: false
+      stanford_filtered_lists:
+        weight: 26
+        enabled: false
+      stanford_gallery:
+        weight: 27
+        enabled: false
+      stanford_layout:
+        weight: 28
+        enabled: false
+      stanford_lists:
+        weight: 29
+        enabled: false
+      stanford_media_caption:
+        weight: 30
+        enabled: false
+      stanford_page_title_banner:
+        weight: 31
+        enabled: false
+      stanford_person_cta:
+        weight: 32
+        enabled: false
+      stanford_schedule:
+        weight: 33
+        enabled: false
+      stanford_spacer:
+        weight: 34
+        enabled: false
+      stanford_stat_card:
+        weight: 35
+        enabled: false
+      stanford_wysiwyg:
+        weight: 36
+        enabled: false
 field_type: entity_reference_revisions

--- a/docroot/profiles/lagunita/csp_profile/config/sync/split/csp/field.storage.paragraph.csp_course_card_instructors.yml
+++ b/docroot/profiles/lagunita/csp_profile/config/sync/split/csp/field.storage.paragraph.csp_course_card_instructors.yml
@@ -13,7 +13,7 @@ settings:
   target_type: paragraph
 module: entity_reference_revisions
 locked: false
-cardinality: 3
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Config-only change to remove the 3 instructor limit from the faux course card

# Review By (Date)
- 8/14

# Urgency
- medium

# Steps to Test

1. pull branch, `drush cim`
2. create a faux course card anywhere
3. verify you can add more than three instructors to the faux course card

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
